### PR TITLE
update to use polkadotXcm for moonbeam

### DIFF
--- a/packages/networks/src/chains/moonbeam.ts
+++ b/packages/networks/src/chains/moonbeam.ts
@@ -6,6 +6,29 @@ const custom = {
     dot: 42259045809535163221576417993425387648n,
     aca: 224821240862170613278369189818311486111n,
     ldot: 225719522181998468294117309041779353812n,
+    xcmDot: { Concrete: { parents: 1, interior: 'Here' } },
+    xcmAca: {
+      Concrete: {
+        parents: 1,
+        interior: {
+          X2: [
+            { Parachain: 2000 },
+            { GeneralKey: { data: '0x0000000000000000000000000000000000000000000000000000000000000000', length: 2 } },
+          ],
+        },
+      },
+    },
+    xcmLdot: {
+      Concrete: {
+        parents: 1,
+        interior: {
+          X2: [
+            { Parachain: 2000 },
+            { GeneralKey: { data: '0x0003000000000000000000000000000000000000000000000000000000000000', length: 2 } },
+          ],
+        },
+      },
+    },
   },
   moonriver: {},
 }

--- a/packages/polkadot/src/acala.moonbeam.test.ts
+++ b/packages/polkadot/src/acala.moonbeam.test.ts
@@ -48,7 +48,7 @@ describe('acala & moonbeam', async () => {
       routeChain: polkadotClient,
       isCheckUmp: true,
 
-      tx: tx.xtokens.transfer({ ForeignAsset: moonbeamDot }, 1e12, tx.xtokens.parachainV3(acala.paraId!)),
+      tx: tx.xcmPallet.transferAssetsV3(moonbeam.custom.xcmDot, 1e12, tx.xcmPallet.parachainV3(1, acala.paraId!)),
     }
   })
 
@@ -82,7 +82,7 @@ describe('acala & moonbeam', async () => {
       toBalance: query.balances,
       toAccount: defaultAccounts.bob,
 
-      tx: tx.xtokens.transfer({ ForeignAsset: moonbeam.custom.aca }, 1e12, tx.xtokens.parachainV3(acala.paraId!)),
+      tx: tx.xcmPallet.transferAssetsV3(moonbeam.custom.xcmAca, 1e12, tx.xcmPallet.parachainV3(1, acala.paraId!)),
     }
   })
 
@@ -116,7 +116,7 @@ describe('acala & moonbeam', async () => {
       toBalance: query.tokens(acala.custom.ldot),
       toAccount: defaultAccounts.bob,
 
-      tx: tx.xtokens.transfer({ ForeignAsset: moonbeam.custom.ldot }, 1e12, tx.xtokens.parachainV3(acala.paraId!)),
+      tx: tx.xcmPallet.transferAssetsV3(moonbeam.custom.xcmLdot, 1e12, tx.xcmPallet.parachainV3(1, acala.paraId!)),
     }
   })
 })

--- a/packages/shared/src/api/index.ts
+++ b/packages/shared/src/api/index.ts
@@ -192,6 +192,34 @@ export const xcmPallet = {
     ({ api }: { api: ApiPromise }) => {
       return api.tx.polkadotXcm.send(dest, xcm)
     },
+  transferAssetsV3:
+    (token: any, amount: any, dest: any) =>
+    ({ api }: { api: ApiPromise }, acc: any) =>
+      (api.tx.xcmPallet || api.tx.polkadotXcm).transferAssets(
+        dest,
+        {
+          V3: {
+            parents: 0,
+            interior: {
+              X1: {
+                AccountId32: {
+                  id: acc,
+                },
+              },
+            },
+          },
+        },
+        {
+          V3: [
+            {
+              id: token,
+              fun: { Fungible: amount },
+            },
+          ],
+        },
+        0,
+        'Unlimited',
+      ),
 }
 
 export const tx = {


### PR DESCRIPTION
xtokens is removed from Moonbeam, so updating to use polkadotXcm.transferAssets instead