### PR TITLE
Add missing `nominate/chill` tests

### DIFF
--- a/packages/kusama/src/__snapshots__/kusamaNominationPools.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/kusamaNominationPools.e2e.test.ts.snap
@@ -263,8 +263,8 @@ exports[`Kusama Nomination Pools > nomination pool lifecycle test > nomination p
         "class": "Normal",
         "paysFee": "Yes",
         "weight": {
-          "proofSize": "(rounded 15000)",
-          "refTime": "(rounded 1200000000)",
+          "proofSize": "(rounded 45000)",
+          "refTime": "(rounded 1500000000)",
         },
       },
     },

--- a/packages/kusama/src/__snapshots__/kusamaNominationPools.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/kusamaNominationPools.e2e.test.ts.snap
@@ -229,6 +229,25 @@ exports[`Kusama Nomination Pools > nomination pool lifecycle test > join nominat
 ]
 `;
 
+exports[`Kusama Nomination Pools > nomination pool lifecycle test > nomination pool validator selection events 1`] = `
+[
+  {
+    "data": {
+      "dispatchInfo": {
+        "class": "Normal",
+        "paysFee": "Yes",
+        "weight": {
+          "proofSize": "(rounded 37000)",
+          "refTime": "(rounded 1400000000)",
+        },
+      },
+    },
+    "method": "ExtrinsicSuccess",
+    "section": "system",
+  },
+]
+`;
+
 exports[`Kusama Nomination Pools > nomination pool lifecycle test > set state events 1`] = `
 [
   {

--- a/packages/kusama/src/__snapshots__/kusamaNominationPools.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/kusamaNominationPools.e2e.test.ts.snap
@@ -114,6 +114,32 @@ exports[`Kusama Nomination Pools > nomination pool lifecycle test > bond extra f
 ]
 `;
 
+exports[`Kusama Nomination Pools > nomination pool lifecycle test > chill events 1`] = `
+[
+  {
+    "data": {
+      "stash": "F3opxRbN5ZavB4LTn2UYFiR65bYBcdqyfzfmkutumQadysv",
+    },
+    "method": "Chilled",
+    "section": "staking",
+  },
+  {
+    "data": {
+      "dispatchInfo": {
+        "class": "Normal",
+        "paysFee": "Yes",
+        "weight": {
+          "proofSize": "(rounded 4600)",
+          "refTime": "(rounded 990000000)",
+        },
+      },
+    },
+    "method": "ExtrinsicSuccess",
+    "section": "system",
+  },
+]
+`;
+
 exports[`Kusama Nomination Pools > nomination pool lifecycle test > claim commission events 1`] = `
 [
   {
@@ -237,8 +263,8 @@ exports[`Kusama Nomination Pools > nomination pool lifecycle test > nomination p
         "class": "Normal",
         "paysFee": "Yes",
         "weight": {
-          "proofSize": "(rounded 37000)",
-          "refTime": "(rounded 1400000000)",
+          "proofSize": "(rounded 15000)",
+          "refTime": "(rounded 1200000000)",
         },
       },
     },

--- a/packages/polkadot/src/__snapshots__/polkadotNominationPools.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadotNominationPools.e2e.test.ts.snap
@@ -114,6 +114,32 @@ exports[`Polkadot Nomination Pools > nomination pool lifecycle test > bond extra
 ]
 `;
 
+exports[`Polkadot Nomination Pools > nomination pool lifecycle test > chill events 1`] = `
+[
+  {
+    "data": {
+      "stash": "13UVJyLnbVp8c4FQeiGG4xVRNURXD6y3qzyjCZgS7dm34uSE",
+    },
+    "method": "Chilled",
+    "section": "staking",
+  },
+  {
+    "data": {
+      "dispatchInfo": {
+        "class": "Normal",
+        "paysFee": "Yes",
+        "weight": {
+          "proofSize": "(rounded 4600)",
+          "refTime": "(rounded 860000000)",
+        },
+      },
+    },
+    "method": "ExtrinsicSuccess",
+    "section": "system",
+  },
+]
+`;
+
 exports[`Polkadot Nomination Pools > nomination pool lifecycle test > claim commission events 1`] = `
 [
   {
@@ -237,8 +263,8 @@ exports[`Polkadot Nomination Pools > nomination pool lifecycle test > nomination
         "class": "Normal",
         "paysFee": "Yes",
         "weight": {
-          "proofSize": "(rounded 27000)",
-          "refTime": "(rounded 1100000000)",
+          "proofSize": "(rounded 12000)",
+          "refTime": "(rounded 1000000000)",
         },
       },
     },

--- a/packages/polkadot/src/__snapshots__/polkadotNominationPools.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadotNominationPools.e2e.test.ts.snap
@@ -263,8 +263,8 @@ exports[`Polkadot Nomination Pools > nomination pool lifecycle test > nomination
         "class": "Normal",
         "paysFee": "Yes",
         "weight": {
-          "proofSize": "(rounded 12000)",
-          "refTime": "(rounded 1000000000)",
+          "proofSize": "(rounded 45000)",
+          "refTime": "(rounded 1300000000)",
         },
       },
     },

--- a/packages/polkadot/src/__snapshots__/polkadotNominationPools.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadotNominationPools.e2e.test.ts.snap
@@ -229,6 +229,25 @@ exports[`Polkadot Nomination Pools > nomination pool lifecycle test > join nomin
 ]
 `;
 
+exports[`Polkadot Nomination Pools > nomination pool lifecycle test > nomination pool validator selection events 1`] = `
+[
+  {
+    "data": {
+      "dispatchInfo": {
+        "class": "Normal",
+        "paysFee": "Yes",
+        "weight": {
+          "proofSize": "(rounded 27000)",
+          "refTime": "(rounded 1100000000)",
+        },
+      },
+    },
+    "method": "ExtrinsicSuccess",
+    "section": "system",
+  },
+]
+`;
+
 exports[`Polkadot Nomination Pools > nomination pool lifecycle test > set state events 1`] = `
 [
   {

--- a/packages/shared/src/nomination-pools.ts
+++ b/packages/shared/src/nomination-pools.ts
@@ -188,14 +188,14 @@ async function nominationPoolCreationFailureTest<
  *     3.4 setting the commission claim permission to permissionless
  *
  * 4. nominating a validator set as the pool's validator
- * 4. having another other account join the pool
- * 5. bonding additional funds from this newcomer account to the pool
- * 6. attempt to claim the pool's (zero) commission as a random account
- * 7. unbonding the additionally bonded funds from the newcomer account
- * 8. setting the pool state to blocked
- * 9. kicking the newcomer account from the pool as the bouncer
- * 10. setting the pool state to destroying
- * 11. attempting to unbond the initial depositor's funds (should fail)
+ * 5. having another other account join the pool
+ * 6. bonding additional funds from this newcomer account to the pool
+ * 7. attempt to claim the pool's (zero) commission as a random account
+ * 8. unbonding the additionally bonded funds from the newcomer account
+ * 9. setting the pool state to blocked
+ * 10. kicking the newcomer account from the pool as the bouncer
+ * 11. setting the pool state to destroying
+ * 12. attempting to unbond the initial depositor's funds (should fail)
  * @param relayChain
  * @param addressEncoding
  */
@@ -378,6 +378,8 @@ async function nominationPoolLifecycleTest(relayChain, addressEncoding: number) 
 
   await relayClient.dev.newBlock()
 
+  // `nominate` does not emit any events from `staking` or `nominationPools` as of
+  // Jan. 2025. #7377 will fix this.
   await checkEvents(nominateEvents, 'staking', 'nominationPools', 'system')
     .redact({ removeKeys: /poolId/ })
     .toMatchSnapshot('nomination pool validator selection events')


### PR DESCRIPTION
Follows #165. With it, I found https://github.com/paritytech/polkadot-sdk/pull/7370, and with https://github.com/paritytech/polkadot-sdk/pull/7377 I realized I forgot to check `nominate/chill` in #165.