### PR TITLE
Introduce more scheduler e2e tests

### DIFF
--- a/packages/kusama/src/__snapshots__/assetHubKusama.scheduler.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/assetHubKusama.scheduler.e2e.test.ts.snap
@@ -47,7 +47,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > cancelling a named scheduled tas
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Canceled",
     "section": "scheduler",
@@ -56,10 +56,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > cancelling a named scheduled tas
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -74,7 +71,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > cancelling a scheduled task is p
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Canceled",
     "section": "scheduler",
@@ -83,10 +80,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > cancelling a scheduled task is p
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -98,8 +92,8 @@ exports[`Asset Hub Kusama Scheduler E2E tests > execution of scheduled preimage 
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -108,10 +102,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > execution of scheduled preimage 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -135,8 +126,8 @@ exports[`Asset Hub Kusama Scheduler E2E tests > priority-based execution of weig
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -145,10 +136,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > priority-based execution of weig
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        1,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -200,8 +188,8 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a call is possible, a
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -210,10 +198,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a call is possible, a
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -226,10 +211,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a call using a preima
   {
     "data": {
       "id": null,
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "CallUnavailable",
     "section": "scheduler",
@@ -253,8 +235,8 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named call is possi
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -263,10 +245,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named call is possi
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -278,8 +257,8 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named periodic task
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -288,10 +267,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named periodic task
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -299,7 +275,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named periodic task
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -311,8 +287,8 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named periodic task
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -321,10 +297,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named periodic task
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -332,7 +305,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named periodic task
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -344,8 +317,8 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named periodic task
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -354,10 +327,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named periodic task
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -369,8 +339,8 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named task after a 
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -379,10 +349,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named task after a 
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -395,7 +362,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named task after a 
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -404,10 +371,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named task after a 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -419,8 +383,8 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a periodic task is po
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -429,10 +393,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a periodic task is po
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -440,7 +401,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a periodic task is po
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -452,8 +413,8 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a periodic task is po
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -462,10 +423,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a periodic task is po
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -473,7 +431,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a periodic task is po
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -485,8 +443,8 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a periodic task is po
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -495,10 +453,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a periodic task is po
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -510,8 +465,8 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a task after a delay 
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -520,10 +475,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a task after a delay 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -536,7 +488,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a task after a delay 
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -545,10 +497,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a task after a delay 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -561,10 +510,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling an overweight call is
   {
     "data": {
       "id": null,
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "PermanentlyOverweight",
     "section": "scheduler",
@@ -580,10 +526,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > setting and canceling retry conf
       "result": {
         "Err": "BadOrigin",
       },
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -591,7 +534,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > setting and canceling retry conf
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -599,7 +542,26 @@ exports[`Asset Hub Kusama Scheduler E2E tests > setting and canceling retry conf
 ]
 `;
 
-exports[`Asset Hub Kusama Scheduler E2E tests > setting and canceling retry configuration for named scheduled tasks > events for retry config cancellation 1`] = `[]`;
+exports[`Asset Hub Kusama Scheduler E2E tests > setting and canceling retry configuration for named scheduled tasks > events for retry config cancellation 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x01000000",
+            "index": 29,
+          },
+        },
+      },
+      "task": "(redacted)",
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
 
 exports[`Asset Hub Kusama Scheduler E2E tests > setting and canceling retry configuration for unnamed scheduled tasks > events for failed task execution 1`] = `
 [
@@ -609,10 +571,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > setting and canceling retry conf
       "result": {
         "Err": "BadOrigin",
       },
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -620,7 +579,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > setting and canceling retry conf
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -628,4 +587,24 @@ exports[`Asset Hub Kusama Scheduler E2E tests > setting and canceling retry conf
 ]
 `;
 
-exports[`Asset Hub Kusama Scheduler E2E tests > setting and canceling retry configuration for unnamed scheduled tasks > events for retry config cancellation 1`] = `[]`;
+exports[`Asset Hub Kusama Scheduler E2E tests > setting and canceling retry configuration for unnamed scheduled tasks > events for retry config cancellation 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "task": "(redacted)",
+    },
+    "method": "RetryCancelled",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": "(redacted)",
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;

--- a/packages/kusama/src/__snapshots__/assetHubKusama.scheduler.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/assetHubKusama.scheduler.e2e.test.ts.snap
@@ -543,3 +543,61 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling an overweight call is
   },
 ]
 `;
+
+exports[`Asset Hub Kusama Scheduler E2E tests > setting and canceling retry configuration for named scheduled tasks > events for failed named task execution 1`] = `
+[
+  {
+    "data": {
+      "id": "(hash)",
+      "result": {
+        "Err": "BadOrigin",
+      },
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 27000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Kusama Scheduler E2E tests > setting and canceling retry configuration for named scheduled tasks > events for retry config cancellation 1`] = `[]`;
+
+exports[`Asset Hub Kusama Scheduler E2E tests > setting and canceling retry configuration for unnamed scheduled tasks > events for failed task execution 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "result": {
+        "Err": "BadOrigin",
+      },
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 27000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Kusama Scheduler E2E tests > setting and canceling retry configuration for unnamed scheduled tasks > events for retry config cancellation 1`] = `[]`;

--- a/packages/kusama/src/__snapshots__/assetHubKusama.scheduler.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/assetHubKusama.scheduler.e2e.test.ts.snap
@@ -131,6 +131,31 @@ exports[`Asset Hub Kusama Scheduler E2E tests > execution of scheduled preimage 
 ]
 `;
 
+exports[`Asset Hub Kusama Scheduler E2E tests > priority-based execution of weighted tasks works correctly > events for priority weighted tasks execution 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
 exports[`Asset Hub Kusama Scheduler E2E tests > schedule named task with wrong origin > events when scheduling named task with insufficient origin 1`] = `
 [
   {

--- a/packages/kusama/src/__snapshots__/assetHubKusama.scheduler.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/assetHubKusama.scheduler.e2e.test.ts.snap
@@ -221,6 +221,97 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named call is possi
 ]
 `;
 
+exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named periodic task that executes multiple times > events for named periodic task execution 1 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 27000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named periodic task that executes multiple times > events for named periodic task execution 2 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 27000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named periodic task that executes multiple times > events for named periodic task execution 3 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
 exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named task after a delay is possible > events for scheduled task execution 1`] = `
 [
   {
@@ -255,6 +346,97 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named task after a 
     },
     "method": "Scheduled",
     "section": "scheduler",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a periodic task is possible > events for  periodic task execution 1 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 27000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a periodic task is possible > events for  periodic task execution 2 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 27000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a periodic task is possible > events for  periodic task execution 3 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
   },
   {
     "data": {

--- a/packages/kusama/src/__snapshots__/assetHubKusama.scheduler.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/assetHubKusama.scheduler.e2e.test.ts.snap
@@ -221,6 +221,34 @@ exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a call is possible, a
 ]
 `;
 
+exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a call using a preimage that gets removed > events for failing scheduled lookup-task execution 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "CallUnavailable",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a call using a preimage that gets removed > note preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
 exports[`Asset Hub Kusama Scheduler E2E tests > scheduling a named call is possible, and the call itself succeeds > events for scheduled task execution 1`] = `
 [
   {

--- a/packages/kusama/src/__snapshots__/assetHubKusama.scheduler.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/assetHubKusama.scheduler.e2e.test.ts.snap
@@ -147,7 +147,7 @@ exports[`Asset Hub Kusama Scheduler E2E tests > priority-based execution of weig
       "result": "Ok",
       "task": [
         "(rounded 27000000)",
-        0,
+        1,
       ],
     },
     "method": "Dispatched",

--- a/packages/kusama/src/__snapshots__/assetHubKusama.scheduler.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/assetHubKusama.scheduler.e2e.test.ts.snap
@@ -94,6 +94,43 @@ exports[`Asset Hub Kusama Scheduler E2E tests > cancelling a scheduled task is p
 ]
 `;
 
+exports[`Asset Hub Kusama Scheduler E2E tests > execution of scheduled preimage lookup call works > events for scheduled lookup-task execution 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Kusama Scheduler E2E tests > execution of scheduled preimage lookup call works > note preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
 exports[`Asset Hub Kusama Scheduler E2E tests > schedule named task with wrong origin > events when scheduling named task with insufficient origin 1`] = `
 [
   {

--- a/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
@@ -47,7 +47,7 @@ exports[`Kusama Scheduler > cancelling a named scheduled task is possible > even
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Canceled",
     "section": "scheduler",
@@ -56,10 +56,7 @@ exports[`Kusama Scheduler > cancelling a named scheduled task is possible > even
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -74,7 +71,7 @@ exports[`Kusama Scheduler > cancelling a scheduled task is possible > events for
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Canceled",
     "section": "scheduler",
@@ -83,10 +80,7 @@ exports[`Kusama Scheduler > cancelling a scheduled task is possible > events for
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -98,8 +92,8 @@ exports[`Kusama Scheduler > execution of scheduled preimage lookup call works > 
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -108,10 +102,7 @@ exports[`Kusama Scheduler > execution of scheduled preimage lookup call works > 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -135,8 +126,8 @@ exports[`Kusama Scheduler > priority-based execution of weighted tasks works cor
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -145,10 +136,7 @@ exports[`Kusama Scheduler > priority-based execution of weighted tasks works cor
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        1,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -200,8 +188,8 @@ exports[`Kusama Scheduler > scheduling a call is possible, and the call itself s
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -210,10 +198,7 @@ exports[`Kusama Scheduler > scheduling a call is possible, and the call itself s
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -226,10 +211,7 @@ exports[`Kusama Scheduler > scheduling a call using a preimage that gets removed
   {
     "data": {
       "id": null,
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "CallUnavailable",
     "section": "scheduler",
@@ -253,8 +235,8 @@ exports[`Kusama Scheduler > scheduling a named call is possible, and the call it
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -263,10 +245,7 @@ exports[`Kusama Scheduler > scheduling a named call is possible, and the call it
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -278,8 +257,8 @@ exports[`Kusama Scheduler > scheduling a named periodic task that executes multi
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -288,10 +267,7 @@ exports[`Kusama Scheduler > scheduling a named periodic task that executes multi
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -299,7 +275,7 @@ exports[`Kusama Scheduler > scheduling a named periodic task that executes multi
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -311,8 +287,8 @@ exports[`Kusama Scheduler > scheduling a named periodic task that executes multi
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -321,10 +297,7 @@ exports[`Kusama Scheduler > scheduling a named periodic task that executes multi
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -332,7 +305,7 @@ exports[`Kusama Scheduler > scheduling a named periodic task that executes multi
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -344,8 +317,8 @@ exports[`Kusama Scheduler > scheduling a named periodic task that executes multi
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -354,10 +327,7 @@ exports[`Kusama Scheduler > scheduling a named periodic task that executes multi
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -369,8 +339,8 @@ exports[`Kusama Scheduler > scheduling a named task after a delay is possible > 
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -379,10 +349,7 @@ exports[`Kusama Scheduler > scheduling a named task after a delay is possible > 
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -395,7 +362,7 @@ exports[`Kusama Scheduler > scheduling a named task after a delay is possible > 
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -404,10 +371,7 @@ exports[`Kusama Scheduler > scheduling a named task after a delay is possible > 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -419,8 +383,8 @@ exports[`Kusama Scheduler > scheduling a periodic task is possible > events for 
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -429,10 +393,7 @@ exports[`Kusama Scheduler > scheduling a periodic task is possible > events for 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -440,7 +401,7 @@ exports[`Kusama Scheduler > scheduling a periodic task is possible > events for 
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -452,8 +413,8 @@ exports[`Kusama Scheduler > scheduling a periodic task is possible > events for 
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -462,10 +423,7 @@ exports[`Kusama Scheduler > scheduling a periodic task is possible > events for 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -473,7 +431,7 @@ exports[`Kusama Scheduler > scheduling a periodic task is possible > events for 
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -485,8 +443,8 @@ exports[`Kusama Scheduler > scheduling a periodic task is possible > events for 
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -495,10 +453,7 @@ exports[`Kusama Scheduler > scheduling a periodic task is possible > events for 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -510,8 +465,8 @@ exports[`Kusama Scheduler > scheduling a task after a delay is possible > events
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -520,10 +475,7 @@ exports[`Kusama Scheduler > scheduling a task after a delay is possible > events
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -536,7 +488,7 @@ exports[`Kusama Scheduler > scheduling a task after a delay is possible > events
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -545,10 +497,7 @@ exports[`Kusama Scheduler > scheduling a task after a delay is possible > events
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -561,10 +510,7 @@ exports[`Kusama Scheduler > scheduling an overweight call is possible, but the c
   {
     "data": {
       "id": null,
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "PermanentlyOverweight",
     "section": "scheduler",
@@ -580,10 +526,7 @@ exports[`Kusama Scheduler > setting and canceling retry configuration for named 
       "result": {
         "Err": "BadOrigin",
       },
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -591,7 +534,7 @@ exports[`Kusama Scheduler > setting and canceling retry configuration for named 
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -599,7 +542,26 @@ exports[`Kusama Scheduler > setting and canceling retry configuration for named 
 ]
 `;
 
-exports[`Kusama Scheduler > setting and canceling retry configuration for named scheduled tasks > events for retry config cancellation 1`] = `[]`;
+exports[`Kusama Scheduler > setting and canceling retry configuration for named scheduled tasks > events for retry config cancellation 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x01000000",
+            "index": 29,
+          },
+        },
+      },
+      "task": "(redacted)",
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
 
 exports[`Kusama Scheduler > setting and canceling retry configuration for unnamed scheduled tasks > events for failed task execution 1`] = `
 [
@@ -609,10 +571,7 @@ exports[`Kusama Scheduler > setting and canceling retry configuration for unname
       "result": {
         "Err": "BadOrigin",
       },
-      "task": [
-        "(rounded 27000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -620,7 +579,7 @@ exports[`Kusama Scheduler > setting and canceling retry configuration for unname
   {
     "data": {
       "index": 0,
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -628,4 +587,24 @@ exports[`Kusama Scheduler > setting and canceling retry configuration for unname
 ]
 `;
 
-exports[`Kusama Scheduler > setting and canceling retry configuration for unnamed scheduled tasks > events for retry config cancellation 1`] = `[]`;
+exports[`Kusama Scheduler > setting and canceling retry configuration for unnamed scheduled tasks > events for retry config cancellation 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "task": "(redacted)",
+    },
+    "method": "RetryCancelled",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": "(redacted)",
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;

--- a/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
@@ -221,6 +221,34 @@ exports[`Kusama Scheduler > scheduling a call is possible, and the call itself s
 ]
 `;
 
+exports[`Kusama Scheduler > scheduling a call using a preimage that gets removed > events for failing scheduled lookup-task execution 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "CallUnavailable",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Kusama Scheduler > scheduling a call using a preimage that gets removed > note preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
 exports[`Kusama Scheduler > scheduling a named call is possible, and the call itself succeeds > events for scheduled task execution 1`] = `
 [
   {

--- a/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
@@ -221,6 +221,97 @@ exports[`Kusama Scheduler > scheduling a named call is possible, and the call it
 ]
 `;
 
+exports[`Kusama Scheduler > scheduling a named periodic task that executes multiple times > events for named periodic task execution 1 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 27000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Kusama Scheduler > scheduling a named periodic task that executes multiple times > events for named periodic task execution 2 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 27000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Kusama Scheduler > scheduling a named periodic task that executes multiple times > events for named periodic task execution 3 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
 exports[`Kusama Scheduler > scheduling a named task after a delay is possible > events for scheduled task execution 1`] = `
 [
   {
@@ -255,6 +346,97 @@ exports[`Kusama Scheduler > scheduling a named task after a delay is possible > 
     },
     "method": "Scheduled",
     "section": "scheduler",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Kusama Scheduler > scheduling a periodic task is possible > events for  periodic task execution 1 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 27000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Kusama Scheduler > scheduling a periodic task is possible > events for  periodic task execution 2 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 27000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Kusama Scheduler > scheduling a periodic task is possible > events for  periodic task execution 3 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
   },
   {
     "data": {

--- a/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
@@ -94,6 +94,43 @@ exports[`Kusama Scheduler > cancelling a scheduled task is possible > events for
 ]
 `;
 
+exports[`Kusama Scheduler > execution of scheduled preimage lookup call works > events for scheduled lookup-task execution 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Kusama Scheduler > execution of scheduled preimage lookup call works > note preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
 exports[`Kusama Scheduler > schedule named task with wrong origin > events when scheduling named task with insufficient origin 1`] = `
 [
   {

--- a/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
@@ -543,3 +543,61 @@ exports[`Kusama Scheduler > scheduling an overweight call is possible, but the c
   },
 ]
 `;
+
+exports[`Kusama Scheduler > setting and canceling retry configuration for named scheduled tasks > events for failed named task execution 1`] = `
+[
+  {
+    "data": {
+      "id": "(hash)",
+      "result": {
+        "Err": "BadOrigin",
+      },
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 27000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Kusama Scheduler > setting and canceling retry configuration for named scheduled tasks > events for retry config cancellation 1`] = `[]`;
+
+exports[`Kusama Scheduler > setting and canceling retry configuration for unnamed scheduled tasks > events for failed task execution 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "result": {
+        "Err": "BadOrigin",
+      },
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 27000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Kusama Scheduler > setting and canceling retry configuration for unnamed scheduled tasks > events for retry config cancellation 1`] = `[]`;

--- a/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
@@ -147,7 +147,7 @@ exports[`Kusama Scheduler > priority-based execution of weighted tasks works cor
       "result": "Ok",
       "task": [
         "(rounded 27000000)",
-        0,
+        1,
       ],
     },
     "method": "Dispatched",

--- a/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
@@ -131,6 +131,31 @@ exports[`Kusama Scheduler > execution of scheduled preimage lookup call works > 
 ]
 `;
 
+exports[`Kusama Scheduler > priority-based execution of weighted tasks works correctly > events for priority weighted tasks execution 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 27000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
 exports[`Kusama Scheduler > schedule named task with wrong origin > events when scheduling named task with insufficient origin 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
@@ -543,3 +543,61 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling an overweight call 
   },
 ]
 `;
+
+exports[`Asset Hub Polkadot Scheduler E2E tests > setting and canceling retry configuration for named scheduled tasks > events for failed named task execution 1`] = `
+[
+  {
+    "data": {
+      "id": "(hash)",
+      "result": {
+        "Err": "BadOrigin",
+      },
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 25000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Polkadot Scheduler E2E tests > setting and canceling retry configuration for named scheduled tasks > events for retry config cancellation 1`] = `[]`;
+
+exports[`Asset Hub Polkadot Scheduler E2E tests > setting and canceling retry configuration for unnamed scheduled tasks > events for failed task execution 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "result": {
+        "Err": "BadOrigin",
+      },
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 25000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Polkadot Scheduler E2E tests > setting and canceling retry configuration for unnamed scheduled tasks > events for retry config cancellation 1`] = `[]`;

--- a/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
@@ -94,6 +94,43 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > cancelling a scheduled task is
 ]
 `;
 
+exports[`Asset Hub Polkadot Scheduler E2E tests > execution of scheduled preimage lookup call works > events for scheduled lookup-task execution 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Polkadot Scheduler E2E tests > execution of scheduled preimage lookup call works > note preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
 exports[`Asset Hub Polkadot Scheduler E2E tests > schedule named task with wrong origin > events when scheduling named task with insufficient origin 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
@@ -131,6 +131,31 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > execution of scheduled preimag
 ]
 `;
 
+exports[`Asset Hub Polkadot Scheduler E2E tests > priority-based execution of weighted tasks works correctly > events for priority weighted tasks execution 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
 exports[`Asset Hub Polkadot Scheduler E2E tests > schedule named task with wrong origin > events when scheduling named task with insufficient origin 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
@@ -221,6 +221,34 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a call is possible,
 ]
 `;
 
+exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a call using a preimage that gets removed > events for failing scheduled lookup-task execution 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "CallUnavailable",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a call using a preimage that gets removed > note preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
 exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named call is possible, and the call itself succeeds > events for scheduled task execution 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
@@ -362,7 +362,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named task after 
 ]
 `;
 
-exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 1 1`] = `
+exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for  periodic task execution 1 1`] = `
 [
   {
     "data": {
@@ -395,7 +395,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is 
 ]
 `;
 
-exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 2 1`] = `
+exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for  periodic task execution 2 1`] = `
 [
   {
     "data": {
@@ -428,40 +428,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is 
 ]
 `;
 
-exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 3 1`] = `
-[
-  {
-    "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
-    },
-    "method": "TotalIssuanceForced",
-    "section": "balances",
-  },
-  {
-    "data": {
-      "id": null,
-      "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
-    },
-    "method": "Dispatched",
-    "section": "scheduler",
-  },
-  {
-    "data": {
-      "index": 0,
-      "when": "(rounded 25000000)",
-    },
-    "method": "Scheduled",
-    "section": "scheduler",
-  },
-]
-`;
-
-exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 4 1`] = `
+exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for  periodic task execution 3 1`] = `
 [
   {
     "data": {

--- a/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
@@ -47,7 +47,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > cancelling a named scheduled t
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Canceled",
     "section": "scheduler",
@@ -56,10 +56,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > cancelling a named scheduled t
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -74,7 +71,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > cancelling a scheduled task is
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Canceled",
     "section": "scheduler",
@@ -83,10 +80,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > cancelling a scheduled task is
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -98,8 +92,8 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > execution of scheduled preimag
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -108,10 +102,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > execution of scheduled preimag
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -135,8 +126,8 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > priority-based execution of we
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -145,10 +136,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > priority-based execution of we
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        1,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -200,8 +188,8 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a call is possible,
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -210,10 +198,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a call is possible,
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -226,10 +211,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a call using a prei
   {
     "data": {
       "id": null,
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "CallUnavailable",
     "section": "scheduler",
@@ -253,8 +235,8 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named call is pos
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -263,10 +245,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named call is pos
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -278,8 +257,8 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named periodic ta
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -288,10 +267,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named periodic ta
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -299,7 +275,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named periodic ta
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -311,8 +287,8 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named periodic ta
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -321,10 +297,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named periodic ta
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -332,7 +305,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named periodic ta
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -344,8 +317,8 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named periodic ta
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -354,10 +327,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named periodic ta
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -369,8 +339,8 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named task after 
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -379,10 +349,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named task after 
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -395,7 +362,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named task after 
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -404,10 +371,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named task after 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -419,8 +383,8 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is 
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -429,10 +393,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -440,7 +401,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is 
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -452,8 +413,8 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is 
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -462,10 +423,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -473,7 +431,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is 
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -485,8 +443,8 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is 
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -495,10 +453,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -510,8 +465,8 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a task after a dela
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -520,10 +475,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a task after a dela
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -536,7 +488,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a task after a dela
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -545,10 +497,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a task after a dela
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -561,10 +510,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling an overweight call 
   {
     "data": {
       "id": null,
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "PermanentlyOverweight",
     "section": "scheduler",
@@ -580,10 +526,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > setting and canceling retry co
       "result": {
         "Err": "BadOrigin",
       },
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -591,7 +534,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > setting and canceling retry co
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -599,7 +542,26 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > setting and canceling retry co
 ]
 `;
 
-exports[`Asset Hub Polkadot Scheduler E2E tests > setting and canceling retry configuration for named scheduled tasks > events for retry config cancellation 1`] = `[]`;
+exports[`Asset Hub Polkadot Scheduler E2E tests > setting and canceling retry configuration for named scheduled tasks > events for retry config cancellation 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x01000000",
+            "index": 1,
+          },
+        },
+      },
+      "task": "(redacted)",
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
 
 exports[`Asset Hub Polkadot Scheduler E2E tests > setting and canceling retry configuration for unnamed scheduled tasks > events for failed task execution 1`] = `
 [
@@ -609,10 +571,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > setting and canceling retry co
       "result": {
         "Err": "BadOrigin",
       },
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -620,7 +579,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > setting and canceling retry co
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -628,4 +587,24 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > setting and canceling retry co
 ]
 `;
 
-exports[`Asset Hub Polkadot Scheduler E2E tests > setting and canceling retry configuration for unnamed scheduled tasks > events for retry config cancellation 1`] = `[]`;
+exports[`Asset Hub Polkadot Scheduler E2E tests > setting and canceling retry configuration for unnamed scheduled tasks > events for retry config cancellation 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "task": "(redacted)",
+    },
+    "method": "RetryCancelled",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": "(redacted)",
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;

--- a/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
@@ -221,6 +221,97 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named call is pos
 ]
 `;
 
+exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named periodic task that executes multiple times > events for named periodic task execution 1 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 25000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named periodic task that executes multiple times > events for named periodic task execution 2 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 25000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named periodic task that executes multiple times > events for named periodic task execution 3 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
 exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named task after a delay is possible > events for scheduled task execution 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
@@ -271,6 +271,130 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a named task after 
 ]
 `;
 
+exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 1 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 25000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 2 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 25000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 3 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 25000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 4 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
 exports[`Asset Hub Polkadot Scheduler E2E tests > scheduling a task after a delay is possible > events for scheduled task execution 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/assetHubPolkadot.scheduler.e2e.test.ts.snap
@@ -147,7 +147,7 @@ exports[`Asset Hub Polkadot Scheduler E2E tests > priority-based execution of we
       "result": "Ok",
       "task": [
         "(rounded 25000000)",
-        0,
+        1,
       ],
     },
     "method": "Dispatched",

--- a/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
@@ -198,6 +198,97 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named call is p
 ]
 `;
 
+exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named periodic task that executes multiple times > events for named periodic task execution 1 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 85000000000000)",
+      "old": "(rounded 85000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "result": "Ok",
+      "task": [
+        "(rounded 5900000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 5900000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named periodic task that executes multiple times > events for named periodic task execution 2 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 85000000000000)",
+      "old": "(rounded 85000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "result": "Ok",
+      "task": [
+        "(rounded 5900000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 5900000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named periodic task that executes multiple times > events for named periodic task execution 3 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 85000000000000)",
+      "old": "(rounded 85000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "result": "Ok",
+      "task": [
+        "(rounded 5900000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
 exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named task after a delay is possible > events for scheduled task execution 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
@@ -248,6 +248,130 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named task afte
 ]
 `;
 
+exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 1 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 85000000000000)",
+      "old": "(rounded 85000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 5900000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 5900000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 2 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 85000000000000)",
+      "old": "(rounded 85000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 5900000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 5900000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 3 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 85000000000000)",
+      "old": "(rounded 85000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 5900000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 5900000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 4 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 85000000000000)",
+      "old": "(rounded 85000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 5900000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
 exports[`Collectives Polkadot Scheduler E2E tests > scheduling a task after a delay is possible > events for scheduled task execution 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
@@ -47,7 +47,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > cancelling a named scheduled
   {
     "data": {
       "index": 0,
-      "when": "(rounded 5900000)",
+      "when": "(redacted)",
     },
     "method": "Canceled",
     "section": "scheduler",
@@ -56,10 +56,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > cancelling a named scheduled
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -74,7 +71,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > cancelling a scheduled task 
   {
     "data": {
       "index": 0,
-      "when": "(rounded 5900000)",
+      "when": "(redacted)",
     },
     "method": "Canceled",
     "section": "scheduler",
@@ -83,10 +80,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > cancelling a scheduled task 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -112,8 +106,8 @@ exports[`Collectives Polkadot Scheduler E2E tests > priority-based execution of 
 [
   {
     "data": {
-      "new_": "(rounded 85000000000000)",
-      "old": "(rounded 85000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -122,10 +116,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > priority-based execution of 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        1,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -177,8 +168,8 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a call is possibl
 [
   {
     "data": {
-      "new_": "(rounded 85000000000000)",
-      "old": "(rounded 85000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -187,10 +178,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a call is possibl
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -216,8 +204,8 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named call is p
 [
   {
     "data": {
-      "new_": "(rounded 85000000000000)",
-      "old": "(rounded 85000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -226,10 +214,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named call is p
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -241,8 +226,8 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named periodic 
 [
   {
     "data": {
-      "new_": "(rounded 85000000000000)",
-      "old": "(rounded 85000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -251,10 +236,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named periodic 
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -262,7 +244,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named periodic 
   {
     "data": {
       "index": 0,
-      "when": "(rounded 5900000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -274,8 +256,8 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named periodic 
 [
   {
     "data": {
-      "new_": "(rounded 85000000000000)",
-      "old": "(rounded 85000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -284,10 +266,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named periodic 
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -295,7 +274,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named periodic 
   {
     "data": {
       "index": 0,
-      "when": "(rounded 5900000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -307,8 +286,8 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named periodic 
 [
   {
     "data": {
-      "new_": "(rounded 85000000000000)",
-      "old": "(rounded 85000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -317,10 +296,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named periodic 
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -332,8 +308,8 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named task afte
 [
   {
     "data": {
-      "new_": "(rounded 85000000000000)",
-      "old": "(rounded 85000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -342,10 +318,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named task afte
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -358,7 +331,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named task afte
   {
     "data": {
       "index": 0,
-      "when": "(rounded 5900000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -367,10 +340,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named task afte
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -382,8 +352,8 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task i
 [
   {
     "data": {
-      "new_": "(rounded 85000000000000)",
-      "old": "(rounded 85000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -392,10 +362,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task i
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -403,7 +370,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task i
   {
     "data": {
       "index": 0,
-      "when": "(rounded 5900000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -415,8 +382,8 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task i
 [
   {
     "data": {
-      "new_": "(rounded 85000000000000)",
-      "old": "(rounded 85000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -425,10 +392,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task i
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -436,7 +400,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task i
   {
     "data": {
       "index": 0,
-      "when": "(rounded 5900000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -448,8 +412,8 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task i
 [
   {
     "data": {
-      "new_": "(rounded 85000000000000)",
-      "old": "(rounded 85000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -458,10 +422,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task i
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -473,8 +434,8 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a task after a de
 [
   {
     "data": {
-      "new_": "(rounded 85000000000000)",
-      "old": "(rounded 85000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -483,10 +444,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a task after a de
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -499,7 +457,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a task after a de
   {
     "data": {
       "index": 0,
-      "when": "(rounded 5900000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -508,10 +466,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a task after a de
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -524,10 +479,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling an overweight cal
   {
     "data": {
       "id": null,
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "PermanentlyOverweight",
     "section": "scheduler",
@@ -543,10 +495,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > setting and canceling retry 
       "result": {
         "Err": "BadOrigin",
       },
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -554,7 +503,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > setting and canceling retry 
   {
     "data": {
       "index": 0,
-      "when": "(rounded 5900000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -562,7 +511,26 @@ exports[`Collectives Polkadot Scheduler E2E tests > setting and canceling retry 
 ]
 `;
 
-exports[`Collectives Polkadot Scheduler E2E tests > setting and canceling retry configuration for named scheduled tasks > events for retry config cancellation 1`] = `[]`;
+exports[`Collectives Polkadot Scheduler E2E tests > setting and canceling retry configuration for named scheduled tasks > events for retry config cancellation 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x01000000",
+            "index": 44,
+          },
+        },
+      },
+      "task": "(redacted)",
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
 
 exports[`Collectives Polkadot Scheduler E2E tests > setting and canceling retry configuration for unnamed scheduled tasks > events for failed task execution 1`] = `
 [
@@ -572,10 +540,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > setting and canceling retry 
       "result": {
         "Err": "BadOrigin",
       },
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -583,7 +548,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > setting and canceling retry 
   {
     "data": {
       "index": 0,
-      "when": "(rounded 5900000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -591,4 +556,24 @@ exports[`Collectives Polkadot Scheduler E2E tests > setting and canceling retry 
 ]
 `;
 
-exports[`Collectives Polkadot Scheduler E2E tests > setting and canceling retry configuration for unnamed scheduled tasks > events for retry config cancellation 1`] = `[]`;
+exports[`Collectives Polkadot Scheduler E2E tests > setting and canceling retry configuration for unnamed scheduled tasks > events for retry config cancellation 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "task": "(redacted)",
+    },
+    "method": "RetryCancelled",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": "(redacted)",
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;

--- a/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
@@ -94,6 +94,20 @@ exports[`Collectives Polkadot Scheduler E2E tests > cancelling a scheduled task 
 ]
 `;
 
+exports[`Collectives Polkadot Scheduler E2E tests > execution of scheduled preimage lookup call works > events for scheduled lookup-task execution 1`] = `[]`;
+
+exports[`Collectives Polkadot Scheduler E2E tests > execution of scheduled preimage lookup call works > note preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
 exports[`Collectives Polkadot Scheduler E2E tests > schedule named task with wrong origin > events when scheduling named task with insufficient origin 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
@@ -520,3 +520,61 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling an overweight cal
   },
 ]
 `;
+
+exports[`Collectives Polkadot Scheduler E2E tests > setting and canceling retry configuration for named scheduled tasks > events for failed named task execution 1`] = `
+[
+  {
+    "data": {
+      "id": "(hash)",
+      "result": {
+        "Err": "BadOrigin",
+      },
+      "task": [
+        "(rounded 5900000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 5900000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Collectives Polkadot Scheduler E2E tests > setting and canceling retry configuration for named scheduled tasks > events for retry config cancellation 1`] = `[]`;
+
+exports[`Collectives Polkadot Scheduler E2E tests > setting and canceling retry configuration for unnamed scheduled tasks > events for failed task execution 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "result": {
+        "Err": "BadOrigin",
+      },
+      "task": [
+        "(rounded 5900000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 5900000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Collectives Polkadot Scheduler E2E tests > setting and canceling retry configuration for unnamed scheduled tasks > events for retry config cancellation 1`] = `[]`;

--- a/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
@@ -339,7 +339,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named task afte
 ]
 `;
 
-exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 1 1`] = `
+exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for  periodic task execution 1 1`] = `
 [
   {
     "data": {
@@ -372,7 +372,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task i
 ]
 `;
 
-exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 2 1`] = `
+exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for  periodic task execution 2 1`] = `
 [
   {
     "data": {
@@ -405,40 +405,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task i
 ]
 `;
 
-exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 3 1`] = `
-[
-  {
-    "data": {
-      "new_": "(rounded 85000000000000)",
-      "old": "(rounded 85000000000000)",
-    },
-    "method": "TotalIssuanceForced",
-    "section": "balances",
-  },
-  {
-    "data": {
-      "id": null,
-      "result": "Ok",
-      "task": [
-        "(rounded 5900000)",
-        0,
-      ],
-    },
-    "method": "Dispatched",
-    "section": "scheduler",
-  },
-  {
-    "data": {
-      "index": 0,
-      "when": "(rounded 5900000)",
-    },
-    "method": "Scheduled",
-    "section": "scheduler",
-  },
-]
-`;
-
-exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for periodic task execution 4 1`] = `
+exports[`Collectives Polkadot Scheduler E2E tests > scheduling a periodic task is possible > events for  periodic task execution 3 1`] = `
 [
   {
     "data": {

--- a/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
@@ -198,6 +198,20 @@ exports[`Collectives Polkadot Scheduler E2E tests > scheduling a call is possibl
 ]
 `;
 
+exports[`Collectives Polkadot Scheduler E2E tests > scheduling a call using a preimage that gets removed > events for failing scheduled lookup-task execution 1`] = `[]`;
+
+exports[`Collectives Polkadot Scheduler E2E tests > scheduling a call using a preimage that gets removed > note preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
 exports[`Collectives Polkadot Scheduler E2E tests > scheduling a named call is possible, and the call itself succeeds > events for scheduled task execution 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
@@ -124,7 +124,7 @@ exports[`Collectives Polkadot Scheduler E2E tests > priority-based execution of 
       "result": "Ok",
       "task": [
         "(rounded 5900000)",
-        0,
+        1,
       ],
     },
     "method": "Dispatched",

--- a/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/collectivesPolkadot.scheduler.e2e.test.ts.snap
@@ -108,6 +108,31 @@ exports[`Collectives Polkadot Scheduler E2E tests > execution of scheduled preim
 ]
 `;
 
+exports[`Collectives Polkadot Scheduler E2E tests > priority-based execution of weighted tasks works correctly > events for priority weighted tasks execution 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 85000000000000)",
+      "old": "(rounded 85000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 5900000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
 exports[`Collectives Polkadot Scheduler E2E tests > schedule named task with wrong origin > events when scheduling named task with insufficient origin 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
@@ -362,7 +362,7 @@ exports[`Polkadot Scheduler > scheduling a named task after a delay is possible 
 ]
 `;
 
-exports[`Polkadot Scheduler > scheduling a periodic task is possible > events for periodic task execution 1 1`] = `
+exports[`Polkadot Scheduler > scheduling a periodic task is possible > events for  periodic task execution 1 1`] = `
 [
   {
     "data": {
@@ -395,7 +395,7 @@ exports[`Polkadot Scheduler > scheduling a periodic task is possible > events fo
 ]
 `;
 
-exports[`Polkadot Scheduler > scheduling a periodic task is possible > events for periodic task execution 2 1`] = `
+exports[`Polkadot Scheduler > scheduling a periodic task is possible > events for  periodic task execution 2 1`] = `
 [
   {
     "data": {
@@ -428,40 +428,7 @@ exports[`Polkadot Scheduler > scheduling a periodic task is possible > events fo
 ]
 `;
 
-exports[`Polkadot Scheduler > scheduling a periodic task is possible > events for periodic task execution 3 1`] = `
-[
-  {
-    "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
-    },
-    "method": "TotalIssuanceForced",
-    "section": "balances",
-  },
-  {
-    "data": {
-      "id": null,
-      "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
-    },
-    "method": "Dispatched",
-    "section": "scheduler",
-  },
-  {
-    "data": {
-      "index": 0,
-      "when": "(rounded 25000000)",
-    },
-    "method": "Scheduled",
-    "section": "scheduler",
-  },
-]
-`;
-
-exports[`Polkadot Scheduler > scheduling a periodic task is possible > events for periodic task execution 4 1`] = `
+exports[`Polkadot Scheduler > scheduling a periodic task is possible > events for  periodic task execution 3 1`] = `
 [
   {
     "data": {

--- a/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
@@ -221,6 +221,34 @@ exports[`Polkadot Scheduler > scheduling a call is possible, and the call itself
 ]
 `;
 
+exports[`Polkadot Scheduler > scheduling a call using a preimage that gets removed > events for failing scheduled lookup-task execution 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "CallUnavailable",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Polkadot Scheduler > scheduling a call using a preimage that gets removed > note preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
 exports[`Polkadot Scheduler > scheduling a named call is possible, and the call itself succeeds > events for scheduled task execution 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
@@ -147,7 +147,7 @@ exports[`Polkadot Scheduler > priority-based execution of weighted tasks works c
       "result": "Ok",
       "task": [
         "(rounded 25000000)",
-        0,
+        1,
       ],
     },
     "method": "Dispatched",

--- a/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
@@ -94,6 +94,43 @@ exports[`Polkadot Scheduler > cancelling a scheduled task is possible > events f
 ]
 `;
 
+exports[`Polkadot Scheduler > execution of scheduled preimage lookup call works > events for scheduled lookup-task execution 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Polkadot Scheduler > execution of scheduled preimage lookup call works > note preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
 exports[`Polkadot Scheduler > schedule named task with wrong origin > events when scheduling named task with insufficient origin 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
@@ -271,6 +271,130 @@ exports[`Polkadot Scheduler > scheduling a named task after a delay is possible 
 ]
 `;
 
+exports[`Polkadot Scheduler > scheduling a periodic task is possible > events for periodic task execution 1 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 25000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Polkadot Scheduler > scheduling a periodic task is possible > events for periodic task execution 2 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 25000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Polkadot Scheduler > scheduling a periodic task is possible > events for periodic task execution 3 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 25000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Polkadot Scheduler > scheduling a periodic task is possible > events for periodic task execution 4 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
 exports[`Polkadot Scheduler > scheduling a task after a delay is possible > events for scheduled task execution 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
@@ -221,6 +221,97 @@ exports[`Polkadot Scheduler > scheduling a named call is possible, and the call 
 ]
 `;
 
+exports[`Polkadot Scheduler > scheduling a named periodic task that executes multiple times > events for named periodic task execution 1 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 25000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Polkadot Scheduler > scheduling a named periodic task that executes multiple times > events for named periodic task execution 2 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 25000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Polkadot Scheduler > scheduling a named periodic task that executes multiple times > events for named periodic task execution 3 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
 exports[`Polkadot Scheduler > scheduling a named task after a delay is possible > events for scheduled task execution 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
@@ -131,6 +131,31 @@ exports[`Polkadot Scheduler > execution of scheduled preimage lookup call works 
 ]
 `;
 
+exports[`Polkadot Scheduler > priority-based execution of weighted tasks works correctly > events for priority weighted tasks execution 1`] = `
+[
+  {
+    "data": {
+      "new_": "(rounded 16000000000000000000)",
+      "old": "(rounded 16000000000000000000)",
+    },
+    "method": "TotalIssuanceForced",
+    "section": "balances",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
 exports[`Polkadot Scheduler > schedule named task with wrong origin > events when scheduling named task with insufficient origin 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
@@ -47,7 +47,7 @@ exports[`Polkadot Scheduler > cancelling a named scheduled task is possible > ev
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Canceled",
     "section": "scheduler",
@@ -56,10 +56,7 @@ exports[`Polkadot Scheduler > cancelling a named scheduled task is possible > ev
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -74,7 +71,7 @@ exports[`Polkadot Scheduler > cancelling a scheduled task is possible > events f
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Canceled",
     "section": "scheduler",
@@ -83,10 +80,7 @@ exports[`Polkadot Scheduler > cancelling a scheduled task is possible > events f
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -98,8 +92,8 @@ exports[`Polkadot Scheduler > execution of scheduled preimage lookup call works 
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -108,10 +102,7 @@ exports[`Polkadot Scheduler > execution of scheduled preimage lookup call works 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -135,8 +126,8 @@ exports[`Polkadot Scheduler > priority-based execution of weighted tasks works c
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -145,10 +136,7 @@ exports[`Polkadot Scheduler > priority-based execution of weighted tasks works c
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        1,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -200,8 +188,8 @@ exports[`Polkadot Scheduler > scheduling a call is possible, and the call itself
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -210,10 +198,7 @@ exports[`Polkadot Scheduler > scheduling a call is possible, and the call itself
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -226,10 +211,7 @@ exports[`Polkadot Scheduler > scheduling a call using a preimage that gets remov
   {
     "data": {
       "id": null,
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "CallUnavailable",
     "section": "scheduler",
@@ -253,8 +235,8 @@ exports[`Polkadot Scheduler > scheduling a named call is possible, and the call 
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -263,10 +245,7 @@ exports[`Polkadot Scheduler > scheduling a named call is possible, and the call 
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -278,8 +257,8 @@ exports[`Polkadot Scheduler > scheduling a named periodic task that executes mul
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -288,10 +267,7 @@ exports[`Polkadot Scheduler > scheduling a named periodic task that executes mul
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -299,7 +275,7 @@ exports[`Polkadot Scheduler > scheduling a named periodic task that executes mul
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -311,8 +287,8 @@ exports[`Polkadot Scheduler > scheduling a named periodic task that executes mul
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -321,10 +297,7 @@ exports[`Polkadot Scheduler > scheduling a named periodic task that executes mul
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -332,7 +305,7 @@ exports[`Polkadot Scheduler > scheduling a named periodic task that executes mul
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -344,8 +317,8 @@ exports[`Polkadot Scheduler > scheduling a named periodic task that executes mul
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -354,10 +327,7 @@ exports[`Polkadot Scheduler > scheduling a named periodic task that executes mul
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -369,8 +339,8 @@ exports[`Polkadot Scheduler > scheduling a named task after a delay is possible 
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -379,10 +349,7 @@ exports[`Polkadot Scheduler > scheduling a named task after a delay is possible 
     "data": {
       "id": "(hash)",
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -395,7 +362,7 @@ exports[`Polkadot Scheduler > scheduling a named task after a delay is possible 
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -404,10 +371,7 @@ exports[`Polkadot Scheduler > scheduling a named task after a delay is possible 
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -419,8 +383,8 @@ exports[`Polkadot Scheduler > scheduling a periodic task is possible > events fo
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -429,10 +393,7 @@ exports[`Polkadot Scheduler > scheduling a periodic task is possible > events fo
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -440,7 +401,7 @@ exports[`Polkadot Scheduler > scheduling a periodic task is possible > events fo
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -452,8 +413,8 @@ exports[`Polkadot Scheduler > scheduling a periodic task is possible > events fo
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -462,10 +423,7 @@ exports[`Polkadot Scheduler > scheduling a periodic task is possible > events fo
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -473,7 +431,7 @@ exports[`Polkadot Scheduler > scheduling a periodic task is possible > events fo
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -485,8 +443,8 @@ exports[`Polkadot Scheduler > scheduling a periodic task is possible > events fo
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -495,10 +453,7 @@ exports[`Polkadot Scheduler > scheduling a periodic task is possible > events fo
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -510,8 +465,8 @@ exports[`Polkadot Scheduler > scheduling a task after a delay is possible > even
 [
   {
     "data": {
-      "new_": "(rounded 16000000000000000000)",
-      "old": "(rounded 16000000000000000000)",
+      "new_": "(redacted)",
+      "old": "(redacted)",
     },
     "method": "TotalIssuanceForced",
     "section": "balances",
@@ -520,10 +475,7 @@ exports[`Polkadot Scheduler > scheduling a task after a delay is possible > even
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -536,7 +488,7 @@ exports[`Polkadot Scheduler > scheduling a task after a delay is possible > even
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -545,10 +497,7 @@ exports[`Polkadot Scheduler > scheduling a task after a delay is possible > even
     "data": {
       "id": null,
       "result": "Ok",
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -561,10 +510,7 @@ exports[`Polkadot Scheduler > scheduling an overweight call is possible, but the
   {
     "data": {
       "id": null,
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "PermanentlyOverweight",
     "section": "scheduler",
@@ -580,10 +526,7 @@ exports[`Polkadot Scheduler > setting and canceling retry configuration for name
       "result": {
         "Err": "BadOrigin",
       },
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -591,7 +534,7 @@ exports[`Polkadot Scheduler > setting and canceling retry configuration for name
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -599,7 +542,26 @@ exports[`Polkadot Scheduler > setting and canceling retry configuration for name
 ]
 `;
 
-exports[`Polkadot Scheduler > setting and canceling retry configuration for named scheduled tasks > events for retry config cancellation 1`] = `[]`;
+exports[`Polkadot Scheduler > setting and canceling retry configuration for named scheduled tasks > events for retry config cancellation 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x01000000",
+            "index": 1,
+          },
+        },
+      },
+      "task": "(redacted)",
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
 
 exports[`Polkadot Scheduler > setting and canceling retry configuration for unnamed scheduled tasks > events for failed task execution 1`] = `
 [
@@ -609,10 +571,7 @@ exports[`Polkadot Scheduler > setting and canceling retry configuration for unna
       "result": {
         "Err": "BadOrigin",
       },
-      "task": [
-        "(rounded 25000000)",
-        0,
-      ],
+      "task": "(redacted)",
     },
     "method": "Dispatched",
     "section": "scheduler",
@@ -620,7 +579,7 @@ exports[`Polkadot Scheduler > setting and canceling retry configuration for unna
   {
     "data": {
       "index": 0,
-      "when": "(rounded 25000000)",
+      "when": "(redacted)",
     },
     "method": "Scheduled",
     "section": "scheduler",
@@ -628,4 +587,24 @@ exports[`Polkadot Scheduler > setting and canceling retry configuration for unna
 ]
 `;
 
-exports[`Polkadot Scheduler > setting and canceling retry configuration for unnamed scheduled tasks > events for retry config cancellation 1`] = `[]`;
+exports[`Polkadot Scheduler > setting and canceling retry configuration for unnamed scheduled tasks > events for retry config cancellation 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "task": "(redacted)",
+    },
+    "method": "RetryCancelled",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "id": null,
+      "result": "Ok",
+      "task": "(redacted)",
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;

--- a/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
@@ -543,3 +543,61 @@ exports[`Polkadot Scheduler > scheduling an overweight call is possible, but the
   },
 ]
 `;
+
+exports[`Polkadot Scheduler > setting and canceling retry configuration for named scheduled tasks > events for failed named task execution 1`] = `
+[
+  {
+    "data": {
+      "id": "(hash)",
+      "result": {
+        "Err": "BadOrigin",
+      },
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 25000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Polkadot Scheduler > setting and canceling retry configuration for named scheduled tasks > events for retry config cancellation 1`] = `[]`;
+
+exports[`Polkadot Scheduler > setting and canceling retry configuration for unnamed scheduled tasks > events for failed task execution 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "result": {
+        "Err": "BadOrigin",
+      },
+      "task": [
+        "(rounded 25000000)",
+        0,
+      ],
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+  {
+    "data": {
+      "index": 0,
+      "when": "(rounded 25000000)",
+    },
+    "method": "Scheduled",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`Polkadot Scheduler > setting and canceling retry configuration for unnamed scheduled tasks > events for retry config cancellation 1`] = `[]`;

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -3,7 +3,7 @@ import { assert, describe, test } from 'vitest'
 
 import { type Chain, defaultAccountsSr25519 } from '@e2e-test/networks'
 import { type Client, setupNetworks } from '@e2e-test/shared'
-import { check, checkEvents, checkSystemEvents, objectCmp, scheduleCallWithOrigin } from './helpers/index.js'
+import { check, checkEvents, checkSystemEvents, objectCmp, scheduleInlineCallWithOrigin } from './helpers/index.js'
 
 import { sendTransaction } from '@acala-network/chopsticks-testing'
 
@@ -525,7 +525,7 @@ export async function referendumLifecycleTest<
 
   // Cancel the referendum using the scheduler pallet to simulate a root origin
 
-  scheduleCallWithOrigin(client, cancelRefCall.method.toHex(), { system: 'Root' })
+  scheduleInlineCallWithOrigin(client, cancelRefCall.method.toHex(), { system: 'Root' })
 
   await client.dev.newBlock()
 
@@ -771,7 +771,7 @@ export async function referendumLifecycleKillTest<
    * Kill the referendum using the scheduler pallet to simulate a root origin for the call.
    */
 
-  scheduleCallWithOrigin(client, killRefCall.method.toHex(), { system: 'Root' })
+  scheduleInlineCallWithOrigin(client, killRefCall.method.toHex(), { system: 'Root' })
 
   await client.dev.newBlock()
 

--- a/packages/shared/src/nomination-pools.ts
+++ b/packages/shared/src/nomination-pools.ts
@@ -9,7 +9,7 @@ import {
   createAndBondAccounts,
   getValidators,
   objectCmp,
-  scheduleCallWithOrigin,
+  scheduleInlineCallWithOrigin,
   setValidatorsStorage,
 } from './helpers/index.js'
 
@@ -842,7 +842,7 @@ async function nominationPoolGlobalConfigTest<
   ]
 
   for (const [origin, inc] of originsAndIncrements) {
-    scheduleCallWithOrigin(client, setConfigsCall(inc).method.toHex(), origin)
+    scheduleInlineCallWithOrigin(client, setConfigsCall(inc).method.toHex(), origin)
 
     await client.dev.newBlock()
 
@@ -1029,7 +1029,7 @@ async function nominationPoolsUpdateRolesTest<
     { Set: defaultAccountsSr25519.eve.address },
   )
 
-  scheduleCallWithOrigin(client, updateRolesCall.method.toHex(), { system: 'Root' })
+  scheduleInlineCallWithOrigin(client, updateRolesCall.method.toHex(), { system: 'Root' })
 
   await client.dev.newBlock()
 

--- a/packages/shared/src/scheduler.ts
+++ b/packages/shared/src/scheduler.ts
@@ -641,6 +641,104 @@ async function scheduleLookupCall<
   )
 }
 
+/**
+ * Test the scheduling of a periodic task that executes multiple times:
+ *
+ * 1. Create a Root-origin call to adjust total issuance
+ * 2. Schedule it to run every other block, starting 2 blocks after scheduling
+ * 3. Verify it executes 3 times at the correct intervals
+ */
+export async function schedulePeriodicTask<
+  TCustom extends Record<string, unknown> | undefined,
+  TInitStorages extends Record<string, Record<string, any>> | undefined,
+>(client: Client<TCustom, TInitStorages>) {
+  const period = 2 // blocks between executions
+  const repetitions = 4 // total number of executions
+
+  const adjustIssuanceTx = client.api.tx.balances.forceAdjustTotalIssuance('Increase', 1)
+
+  let currBlockNumber = (await client.api.rpc.chain.getHeader()).number.toNumber()
+  const scheduleTx = client.api.tx.scheduler.schedule(
+    currBlockNumber + 2, // when
+    [period, repetitions], // maybe_periodic: [period, repetitions]
+    0, // priority
+    adjustIssuanceTx, // call
+  )
+
+  scheduleInlineCallWithOrigin(client, scheduleTx.method.toHex(), { system: 'Root' })
+  const initialTotalIssuance = await client.api.query.balances.totalIssuance()
+
+  // Move to first execution block
+  await client.dev.newBlock()
+  currBlockNumber += 1
+
+  // Initial agenda check
+  let scheduled = await client.api.query.scheduler.agenda(currBlockNumber + 1)
+  assert(scheduled.length === 1)
+  assert(scheduled[0].isSome)
+  await check(scheduled[0].unwrap()).toMatchObject({
+    maybeId: null,
+    priority: 0,
+    call: { inline: adjustIssuanceTx.method.toHex() },
+    // The number of repetitions is reduced by 1 because the first scheduled execution has already occurred:
+    // it is exactly this task.
+    maybePeriodic: [period, repetitions - 1],
+    origin: {
+      system: {
+        root: null,
+      },
+    },
+  })
+
+  // The task has a period of .
+  for (let i = 1; i <= repetitions; i++) {
+    // Execution block
+    await client.dev.newBlock()
+    currBlockNumber += 1
+
+    await checkSystemEvents(client, 'scheduler', {
+      section: 'balances',
+      method: 'TotalIssuanceForced',
+    }).toMatchSnapshot(`events for periodic task execution ${i}`)
+
+    const currentTotalIssuance = await client.api.query.balances.totalIssuance()
+    assert(currentTotalIssuance.eq(initialTotalIssuance.addn(i)))
+
+    // Check agenda for next scheduled execution (if not the last iteration)
+    if (i < repetitions) {
+      scheduled = await client.api.query.scheduler.agenda(currBlockNumber + 2)
+      assert(scheduled.length === 1)
+      assert(scheduled[0].isSome)
+      let maybePeriodic: [number, number] | null
+      if (i === repetitions - 1) {
+        maybePeriodic = null
+      } else {
+        maybePeriodic = [period, repetitions - (i + 1)]
+      }
+
+      await check(scheduled[0].unwrap()).toMatchObject({
+        maybeId: null,
+        priority: 0,
+        call: { inline: adjustIssuanceTx.method.toHex() },
+        maybePeriodic: maybePeriodic,
+        origin: {
+          system: {
+            root: null,
+          },
+        },
+      })
+    }
+
+    // Skip one block (no execution)
+    await client.dev.newBlock()
+    currBlockNumber += 1
+  }
+
+  // Verify task is removed after all executions
+  scheduled = await client.api.query.scheduler.agenda(currBlockNumber + 1)
+  assert(scheduled.length === 0)
+}
+
 export function schedulerE2ETests<
   TCustom extends Record<string, unknown> | undefined,
   TInitStoragesRelay extends Record<string, Record<string, any>> | undefined,
@@ -694,6 +792,10 @@ export function schedulerE2ETests<
 
     test('execution of scheduled preimage lookup call works', async () => {
       await scheduleLookupCall(client)
+    })
+
+    test('scheduling a periodic task is possible', async () => {
+      await schedulePeriodicTask(client)
     })
   })
 }

--- a/packages/shared/src/scheduler.ts
+++ b/packages/shared/src/scheduler.ts
@@ -874,6 +874,11 @@ export async function schedulePriorityWeightedTasks<
   await client.dev.newBlock()
   currBlockNumber += 1
 
+  // Check events - should only see one execution
+  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' }).toMatchSnapshot(
+    'events for priority weighted tasks execution',
+  )
+
   // Check that high priority task executed
   const midTotalIssuance = await client.api.query.balances.totalIssuance()
   assert(midTotalIssuance.eq(initialTotalIssuance.addn(2)))
@@ -908,11 +913,6 @@ export async function schedulePriorityWeightedTasks<
   // Verify agenda is now empty
   scheduled = await client.api.query.scheduler.agenda(currBlockNumber - 1)
   assert(scheduled.length === 0)
-
-  // Check events - should only see one execution
-  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' }).toMatchSnapshot(
-    'events for priority weighted tasks execution',
-  )
 }
 
 export function schedulerE2ETests<

--- a/packages/shared/src/scheduler.ts
+++ b/packages/shared/src/scheduler.ts
@@ -51,7 +51,18 @@ export async function badOriginHelper<
   assert(dispatchError.isBadOrigin)
 }
 
+/**
+ * The period of the periodic task.
+ *
+ * Used in test to scheduling of periodic tasks.
+ */
 const PERIOD = 2
+
+/**
+ * The number of repetitions that a given periodic task should run for.
+ *
+ * Used in test to scheduling of periodic tasks.
+ */
 const REPETITIONS = 3
 
 /// -------
@@ -219,9 +230,11 @@ export async function scheduledCallExecutes<
   await client.dev.newBlock()
   currBlockNumber += 1
 
-  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' }).toMatchSnapshot(
-    'events for scheduled task execution',
-  )
+  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' })
+    .redact({
+      redactKeys: /new|old|when|task/,
+    })
+    .toMatchSnapshot('events for scheduled task execution')
 
   const newTotalIssuance = await client.api.query.balances.totalIssuance()
   assert(newTotalIssuance.eq(oldTotalIssuance.addn(1)))
@@ -276,9 +289,11 @@ export async function scheduledNamedCallExecutes<
   await client.dev.newBlock()
   currBlockNumber += 1
 
-  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' }).toMatchSnapshot(
-    'events for scheduled task execution',
-  )
+  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' })
+    .redact({
+      redactKeys: /new|old|when|task/,
+    })
+    .toMatchSnapshot('events for scheduled task execution')
 
   const newTotalIssuance = await client.api.query.balances.totalIssuance()
   assert(newTotalIssuance.eq(oldTotalIssuance.addn(1)))
@@ -324,9 +339,11 @@ export async function cancelScheduledTask<
   // This should capture 2 system events, and no `TotalIssuanceForced`.
   // 1. One system event will be for the test-specific dispatch injected via the helper `scheduleInlineCallWithOrigin`
   // 2. The other will be for the cancellation of the scheduled task
-  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' }).toMatchSnapshot(
-    'events for scheduled task cancellation',
-  )
+  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' })
+    .redact({
+      redactKeys: /new|old|when|task/,
+    })
+    .toMatchSnapshot('events for scheduled task cancellation')
 
   scheduled = await client.api.query.scheduler.agenda(currBlockNumber + 1)
   assert(scheduled.length === 0)
@@ -373,9 +390,11 @@ export async function cancelScheduledNamedTask<
   await client.dev.newBlock()
   currBlockNumber += 1
 
-  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' }).toMatchSnapshot(
-    'events for scheduled task cancellation',
-  )
+  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' })
+    .redact({
+      redactKeys: /when|task/,
+    })
+    .toMatchSnapshot('events for scheduled task cancellation')
 
   scheduled = await client.api.query.scheduler.agenda(currBlockNumber + 1)
   assert(scheduled.length === 0)
@@ -407,7 +426,11 @@ export async function scheduleTaskAfterDelay<
   let scheduled = await client.api.query.scheduler.agenda(currBlockNumber + 1)
   assert(scheduled.length === 0)
 
-  await checkSystemEvents(client, 'scheduler').toMatchSnapshot('events when scheduling task with delay')
+  await checkSystemEvents(client, 'scheduler')
+    .redact({
+      redactKeys: /when|task/,
+    })
+    .toMatchSnapshot('events when scheduling task with delay')
 
   await client.dev.newBlock()
   currBlockNumber += 1
@@ -432,9 +455,11 @@ export async function scheduleTaskAfterDelay<
   await client.dev.newBlock()
   currBlockNumber += 1
 
-  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' }).toMatchSnapshot(
-    'events for scheduled task execution',
-  )
+  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' })
+    .redact({
+      redactKeys: /new|old|when|task/,
+    })
+    .toMatchSnapshot('events for scheduled task execution')
 
   const newTotalIssuance = await client.api.query.balances.totalIssuance()
   assert(newTotalIssuance.eq(oldTotalIssuance.addn(1)))
@@ -465,7 +490,11 @@ export async function scheduleNamedTaskAfterDelay<
   let scheduled = await client.api.query.scheduler.agenda(currBlockNumber + 1)
   assert(scheduled.length === 0)
 
-  await checkSystemEvents(client, 'scheduler').toMatchSnapshot('events when scheduling task with delay')
+  await checkSystemEvents(client, 'scheduler')
+    .redact({
+      redactKeys: /when|task/,
+    })
+    .toMatchSnapshot('events when scheduling task with delay')
 
   await client.dev.newBlock()
   currBlockNumber += 1
@@ -490,9 +519,11 @@ export async function scheduleNamedTaskAfterDelay<
   await client.dev.newBlock()
   currBlockNumber += 1
 
-  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' }).toMatchSnapshot(
-    'events for scheduled task execution',
-  )
+  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' })
+    .redact({
+      redactKeys: /new|old|when|task/,
+    })
+    .toMatchSnapshot('events for scheduled task execution')
 
   const newTotalIssuance = await client.api.query.balances.totalIssuance()
   assert(newTotalIssuance.eq(oldTotalIssuance.addn(1)))
@@ -563,7 +594,11 @@ export async function scheduledOverweightCallFails<
 
   // Check that an event was emitted certifying the scheduled call as overweight
 
-  await checkSystemEvents(client, 'scheduler').toMatchSnapshot('events when scheduling overweight task')
+  await checkSystemEvents(client, 'scheduler')
+    .redact({
+      redactKeys: /task/,
+    })
+    .toMatchSnapshot('events when scheduling overweight task')
 
   // Check that the call remains in the agenda for the original block it was scheduled in
   scheduled = await client.api.query.scheduler.agenda(currBlockNumber)
@@ -637,9 +672,11 @@ async function scheduleLookupCall<
     assert(newTotalIssuance.eq(oldTotalIssuance.addn(1)))
   }
 
-  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' }).toMatchSnapshot(
-    'events for scheduled lookup-task execution',
-  )
+  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' })
+    .redact({
+      redactKeys: /new|old|task/,
+    })
+    .toMatchSnapshot('events for scheduled lookup-task execution')
 }
 
 /**
@@ -737,20 +774,23 @@ export async function schedulePreimagedCall<
     })
   }
 
-  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' }).toMatchSnapshot(
-    'events for failing scheduled lookup-task execution',
-  )
+  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' })
+    .redact({
+      redactKeys: /task/,
+    })
+    .toMatchSnapshot('events for failing scheduled lookup-task execution')
 
   const newTotalIssuance = await client.api.query.balances.totalIssuance()
   assert(newTotalIssuance.eq(oldTotalIssuance))
 }
 
 /**
- * Helper function containing common logic for testing periodic tasks
+ * Helper function containing common logic for testing periodic tasks.
+ *
  * Tests that:
  * 1. task executes at the correct intervals
- * 2. runs the expected number of executions
- * 3. task is removed from the agenda after all executions
+ * 2. it runs the expected number of executions, and that
+ * 3. the task is removed from the agenda after all executions
  */
 async function testPeriodicTask<
   TCustom extends Record<string, unknown> | undefined,
@@ -777,8 +817,8 @@ async function testPeriodicTask<
     maybeId: taskId ? `0x${Buffer.from(taskId).toString('hex')}` : null,
     priority: 0,
     call: { inline: adjustIssuanceTx.method.toHex() },
-    // The number of repetitions is reduced by 1 because the first scheduled execution has already occurred:
-    // it is exactly this task.
+    // The number of repetitions has already been reduced by 1 because the first scheduled execution has already
+    // occurred: it is exactly this task.
     maybePeriodic: [PERIOD, REPETITIONS - 1],
     origin: {
       system: {
@@ -799,7 +839,11 @@ async function testPeriodicTask<
     await checkSystemEvents(client, 'scheduler', {
       section: 'balances',
       method: 'TotalIssuanceForced',
-    }).toMatchSnapshot(`events for ${taskId ? 'named' : ''} periodic task execution ${i}`)
+    })
+      .redact({
+        redactKeys: /new|old|task|when/,
+      })
+      .toMatchSnapshot(`events for ${taskId ? 'named' : ''} periodic task execution ${i}`)
 
     const currentTotalIssuance = await client.api.query.balances.totalIssuance()
     assert(currentTotalIssuance.eq(initialTotalIssuance.addn(i)))
@@ -892,18 +936,13 @@ export async function scheduleNamedPeriodicTask<
 
 /**
  * Test priority-based execution of weighted tasks:
- *
- * Note: Current behavior (pre polkadot-sdk#7790) incorrectly drops postponed tasks from
- * the agenda when they cannot be executed due to weight constraints. PR #7790 fixes this
- * by ensuring postponed tasks are put back into the agenda for the next block.
- *
  * 1. Create two transactions with weights that exceed half the maximum weight per block
  * 2. Schedule them for the same block with different priorities
  * 3. Verify that:
  *    - The higher priority task executes first and is removed from agenda
- *    - The lower priority task is incorrectly dropped (current behavior)
- *    - The incompleteSince storage is updated correctly
- *    - No tasks execute in the next block since the low priority task was dropped
+ *    - The lower priority task is not executed in the first block
+ *    - The lower priority task is executed in the second block
+ *    - The `incompleteSince` storage is updated correctly
  */
 export async function schedulePriorityWeightedTasks<
   TCustom extends Record<string, unknown> | undefined,
@@ -912,7 +951,7 @@ export async function schedulePriorityWeightedTasks<
   const adjustIssuanceHighTx = client.api.tx.balances.forceAdjustTotalIssuance('Increase', 2)
   const adjustIssuanceLowTx = client.api.tx.balances.forceAdjustTotalIssuance('Increase', 1)
 
-  // Get maximum weight and create tasks that use 60% of it each
+  // Get the maximum weight schedulable per block, and create tasks that each use 60% of it.
   const { refTime, proofSize }: SpWeightsWeightV2Weight = client.api.consts.scheduler.maximumWeight
   const taskWeight = {
     refTime: refTime.unwrap().muln(60).divn(100),
@@ -922,7 +961,8 @@ export async function schedulePriorityWeightedTasks<
   const highPriorityTx = client.api.tx.utility.withWeight(adjustIssuanceHighTx, taskWeight)
   const lowPriorityTx = client.api.tx.utility.withWeight(adjustIssuanceLowTx, taskWeight)
 
-  let currBlockNumber = (await client.api.rpc.chain.getHeader()).number.toNumber()
+  const initBlockNumber = (await client.api.rpc.chain.getHeader()).number.toNumber()
+  let currBlockNumber = initBlockNumber
   const targetBlock = currBlockNumber + 2
 
   // Schedule both tasks for the same block with different priorities
@@ -962,7 +1002,7 @@ export async function schedulePriorityWeightedTasks<
 
   const initialTotalIssuance = await client.api.query.balances.totalIssuance()
 
-  // Move to execution block
+  // Move to block just before scheduled execution
   await client.dev.newBlock()
   currBlockNumber += 1
 
@@ -975,16 +1015,18 @@ export async function schedulePriorityWeightedTasks<
   await client.dev.newBlock()
   currBlockNumber += 1
 
-  // Check events - should only see one execution
-  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' }).toMatchSnapshot(
-    'events for priority weighted tasks execution',
-  )
+  // Check events - there should only be one execution
+  await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' })
+    .redact({
+      redactKeys: /new|old|task/,
+    })
+    .toMatchSnapshot('events for priority weighted tasks execution')
 
-  // Check that high priority task executed
+  // Check that *only* the high priority task executed
   const midTotalIssuance = await client.api.query.balances.totalIssuance()
   assert(midTotalIssuance.eq(initialTotalIssuance.addn(2)))
 
-  // Verify incompleteSince is set to current block
+  // Verify `incompleteSince` is set to current block
   const incompleteSince = await client.api.query.scheduler.incompleteSince()
   assert(incompleteSince.isSome)
   assert(incompleteSince.unwrap().eq(currBlockNumber))
@@ -1000,19 +1042,23 @@ export async function schedulePriorityWeightedTasks<
     origin: { system: { root: null } },
   })
 
-  // Execute second scheduled task
+  // Move to the next block, where the lower priority task will execute
   await client.dev.newBlock()
   currBlockNumber += 1
 
   const finalTotalIssuance = await client.api.query.balances.totalIssuance()
   assert(finalTotalIssuance.eq(initialTotalIssuance.addn(3)))
 
-  // Verify incompleteSince has been unset
+  // Verify `incompleteSince` has been unset
   const finalIncompleteSince = await client.api.query.scheduler.incompleteSince()
   assert(finalIncompleteSince.isNone)
 
   // Verify agenda is now empty
+  scheduled = await client.api.query.scheduler.agenda(initBlockNumber)
+  assert(scheduled.length === 0)
   scheduled = await client.api.query.scheduler.agenda(currBlockNumber - 1)
+  assert(scheduled.length === 0)
+  scheduled = await client.api.query.scheduler.agenda(currBlockNumber)
   assert(scheduled.length === 0)
 }
 
@@ -1085,7 +1131,11 @@ export async function scheduleWithRetryConfig<
   await client.dev.newBlock()
 
   // Check failure events
-  await checkSystemEvents(client, 'scheduler').toMatchSnapshot('events for failed task execution')
+  await checkSystemEvents(client, 'scheduler')
+    .redact({
+      redactKeys: /task|when/,
+    })
+    .toMatchSnapshot('events for failed task execution')
 
   // Verify task failed and was rescheduled
   scheduled = await client.api.query.scheduler.agenda(initialBlockNumber + 3)
@@ -1106,10 +1156,16 @@ export async function scheduleWithRetryConfig<
   const cancelRetryTx = client.api.tx.scheduler.cancelRetry([initialBlockNumber + 6, 0])
   scheduleInlineCallWithOrigin(client, cancelRetryTx.method.toHex(), { system: 'Root' })
 
-  await client.dev.newBlock({ count: 2 })
+  await client.dev.newBlock()
 
   // Check retry cancellation events
-  await checkSystemEvents(client, 'scheduler').toMatchSnapshot('events for retry config cancellation')
+  await checkSystemEvents(client, 'scheduler')
+    .redact({
+      redactKeys: /task/,
+    })
+    .toMatchSnapshot('events for retry config cancellation')
+
+  await client.dev.newBlock()
 
   // Verify task is still scheduled but without retry config
   scheduled = await client.api.query.scheduler.agenda(initialBlockNumber + 6)
@@ -1187,7 +1243,11 @@ export async function scheduleNamedWithRetryConfig<
   await client.dev.newBlock()
 
   // Check failure events
-  await checkSystemEvents(client, 'scheduler').toMatchSnapshot('events for failed named task execution')
+  await checkSystemEvents(client, 'scheduler')
+    .redact({
+      redactKeys: /task|when/,
+    })
+    .toMatchSnapshot('events for failed named task execution')
 
   // Verify task failed and was rescheduled
   scheduled = await client.api.query.scheduler.agenda(initialBlockNumber + 3)
@@ -1212,10 +1272,16 @@ export async function scheduleNamedWithRetryConfig<
   let cancelRetryTx = client.api.tx.scheduler.cancelRetryNamed(taskId)
   scheduleInlineCallWithOrigin(client, cancelRetryTx.method.toHex(), { system: 'Root' })
 
-  await client.dev.newBlock({ count: 2 })
+  await client.dev.newBlock()
 
   // Check retry cancellation events
-  await checkSystemEvents(client, 'scheduler').toMatchSnapshot('events for retry config cancellation')
+  await checkSystemEvents(client, 'scheduler')
+    .redact({
+      redactKeys: /task/,
+    })
+    .toMatchSnapshot('events for retry config cancellation')
+
+  await client.dev.newBlock()
 
   // Verify task is still scheduled but without retry config
   scheduled = await client.api.query.scheduler.agenda(initialBlockNumber + 6)

--- a/packages/shared/src/staking.ts
+++ b/packages/shared/src/staking.ts
@@ -3,7 +3,7 @@ import BN from 'bn.js'
 
 import { type Chain, defaultAccountsSr25519 } from '@e2e-test/networks'
 import { type Client, setupNetworks } from '@e2e-test/shared'
-import { check, checkEvents, checkSystemEvents, scheduleCallWithOrigin } from './helpers/index.js'
+import { check, checkEvents, checkSystemEvents, scheduleInlineCallWithOrigin } from './helpers/index.js'
 
 import { sendTransaction } from '@acala-network/chopsticks-testing'
 import type { SubmittableExtrinsic } from '@polkadot/api/types'
@@ -397,7 +397,7 @@ async function forceUnstakeTest<
   let nominatorPrefs = await client.api.query.staking.nominators(bob.address)
   assert(nominatorPrefs.isSome)
 
-  scheduleCallWithOrigin(client, forceUnstakeTx.method.toHex(), { system: 'Root' })
+  scheduleInlineCallWithOrigin(client, forceUnstakeTx.method.toHex(), { system: 'Root' })
 
   await client.dev.newBlock()
 
@@ -544,7 +544,7 @@ async function setMinCommission<
   ]
 
   for (const [origin, inc] of originsAndIncrements) {
-    scheduleCallWithOrigin(client, setMinCommissionCall(inc).method.toHex(), origin)
+    scheduleInlineCallWithOrigin(client, setMinCommissionCall(inc).method.toHex(), origin)
 
     await client.dev.newBlock()
 
@@ -640,7 +640,7 @@ async function setStakingConfigsTest<
 
   const inc = 10
 
-  scheduleCallWithOrigin(client, setStakingConfigsCall(inc).method.toHex(), { system: 'Root' })
+  scheduleInlineCallWithOrigin(client, setStakingConfigsCall(inc).method.toHex(), { system: 'Root' })
 
   await client.dev.newBlock()
 
@@ -746,7 +746,7 @@ async function forceApplyValidatorCommissionTest<
     { Noop: null },
   )
 
-  scheduleCallWithOrigin(client, setStakingConfigsTx.method.toHex(), { system: 'Root' })
+  scheduleInlineCallWithOrigin(client, setStakingConfigsTx.method.toHex(), { system: 'Root' })
 
   await client.dev.newBlock()
 
@@ -808,7 +808,7 @@ async function modifyValidatorCountTest<
 
   /// Run the call with a `Root` origin
 
-  scheduleCallWithOrigin(client, setValidatorCountCall(100).method.toHex(), { system: 'Root' })
+  scheduleInlineCallWithOrigin(client, setValidatorCountCall(100).method.toHex(), { system: 'Root' })
 
   await client.dev.newBlock()
 
@@ -842,7 +842,7 @@ async function modifyValidatorCountTest<
 
   /// Run the call with a `Root` origin
 
-  scheduleCallWithOrigin(client, increaseValidatorCountCall(100).method.toHex(), { system: 'Root' })
+  scheduleInlineCallWithOrigin(client, increaseValidatorCountCall(100).method.toHex(), { system: 'Root' })
 
   await client.dev.newBlock()
 
@@ -871,7 +871,7 @@ async function modifyValidatorCountTest<
 
   /// Run the call with a `Root` origin
 
-  scheduleCallWithOrigin(client, scaleValidatorCountCall(10).method.toHex(), { system: 'Root' })
+  scheduleInlineCallWithOrigin(client, scaleValidatorCountCall(10).method.toHex(), { system: 'Root' })
 
   await client.dev.newBlock()
 
@@ -921,7 +921,7 @@ async function chillOtherTest<
     { Noop: null },
   )
 
-  scheduleCallWithOrigin(client, setStakingConfigsCall.method.toHex(), { system: 'Root' })
+  scheduleInlineCallWithOrigin(client, setStakingConfigsCall.method.toHex(), { system: 'Root' })
 
   await client.dev.newBlock()
 
@@ -1007,7 +1007,7 @@ async function chillOtherTest<
   const successfulCall = setStakingConfigsCalls.pop()
 
   for (const call of setStakingConfigsCalls) {
-    scheduleCallWithOrigin(client, call.method.toHex(), { system: 'Root' })
+    scheduleInlineCallWithOrigin(client, call.method.toHex(), { system: 'Root' })
 
     await client.dev.newBlock()
 
@@ -1037,7 +1037,7 @@ async function chillOtherTest<
   /// To end the test, sucessfully run `chill_other` with the appropriate staking configuration limits all set,
   /// and observe that Bob is forcibly chilled.
 
-  scheduleCallWithOrigin(client, successfulCall!.method.toHex(), { system: 'Root' })
+  scheduleInlineCallWithOrigin(client, successfulCall!.method.toHex(), { system: 'Root' })
 
   await client.dev.newBlock()
 


### PR DESCRIPTION
Closes #202 .

For now, this contains a test to 

- [x] scheduling of tasks with a `Lookup` on their preimage works (https://github.com/polkadot-fellows/runtimes/pull/614/files)
    - The Collectives test case intentionally fails, and will require an update when the upgrade to the fixed runtime occurs.
- [x] add tests to periodic task scheduling
- [x] test setting retry configuration of task (named or otherwise)
- [x] test behavior of retry parameters on scheduled task that purposefully fails