### PR TITLE
Fix staking's slashing test events

### DIFF
--- a/packages/kusama/src/__snapshots__/kusama.staking.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/kusama.staking.e2e.test.ts.snap
@@ -667,88 +667,34 @@ exports[`Kusama Staking > trying to nominate with no bonded funds fails > events
 
 exports[`Kusama Staking > unapplied slash > balances slash events 1`] = `
 [
-  {
-    "event": {
-      "data": [
-        "HNZata7iMYWmk5RvZRTiAsSDhV8366zq2YGb3tLH5Upf74F",
-        5000000000000,
-      ],
-      "index": "0x0409",
-    },
-    "phase": {
-      "initialization": null,
-    },
-    "topics": [],
-  },
-  {
-    "event": {
-      "data": [
-        "FoQJpPyadYccjavVdTWxpxU7rUEaYhfLCPwXgkfD6Zat9QP",
-        10000000000000,
-      ],
-      "index": "0x0409",
-    },
-    "phase": {
-      "initialization": null,
-    },
-    "topics": [],
-  },
-  {
-    "event": {
-      "data": [
-        "Fr4NzY1udSFFLzb2R3qxVQkwz9cZraWkyfH4h3mVVk7BK7P",
-        10000000000000,
-      ],
-      "index": "0x0409",
-    },
-    "phase": {
-      "initialization": null,
-    },
-    "topics": [],
-  },
+  [
+    "HNZata7iMYWmk5RvZRTiAsSDhV8366zq2YGb3tLH5Upf74F",
+    5000000000000,
+  ],
+  [
+    "FoQJpPyadYccjavVdTWxpxU7rUEaYhfLCPwXgkfD6Zat9QP",
+    10000000000000,
+  ],
+  [
+    "Fr4NzY1udSFFLzb2R3qxVQkwz9cZraWkyfH4h3mVVk7BK7P",
+    10000000000000,
+  ],
 ]
 `;
 
 exports[`Kusama Staking > unapplied slash > staking slash events 1`] = `
 [
-  {
-    "event": {
-      "data": [
-        "HNZata7iMYWmk5RvZRTiAsSDhV8366zq2YGb3tLH5Upf74F",
-        5000000000000,
-      ],
-      "index": "0x0602",
-    },
-    "phase": {
-      "initialization": null,
-    },
-    "topics": [],
-  },
-  {
-    "event": {
-      "data": [
-        "FoQJpPyadYccjavVdTWxpxU7rUEaYhfLCPwXgkfD6Zat9QP",
-        10000000000000,
-      ],
-      "index": "0x0602",
-    },
-    "phase": {
-      "initialization": null,
-    },
-    "topics": [],
-  },
-  {
-    "event": {
-      "data": [
-        "Fr4NzY1udSFFLzb2R3qxVQkwz9cZraWkyfH4h3mVVk7BK7P",
-        10000000000000,
-      ],
-      "index": "0x0602",
-    },
-    "phase": {
-      "initialization": null,
-    },
-    "topics": [],
-  },
+  [
+    "HNZata7iMYWmk5RvZRTiAsSDhV8366zq2YGb3tLH5Upf74F",
+    5000000000000,
+  ],
+  [
+    "FoQJpPyadYccjavVdTWxpxU7rUEaYhfLCPwXgkfD6Zat9QP",
+    10000000000000,
+  ],
+  [
+    "Fr4NzY1udSFFLzb2R3qxVQkwz9cZraWkyfH4h3mVVk7BK7P",
+    10000000000000,
+  ],
 ]
 `;

--- a/packages/shared/src/staking.ts
+++ b/packages/shared/src/staking.ts
@@ -1255,10 +1255,10 @@ async function unappliedSlashTest<
     const { event } = record
     if (event.section === 'staking' && event.method === 'Slashed') {
       assert(client.api.events.staking.Slashed.is(event))
-      stakingSlashEvents.push(record)
+      stakingSlashEvents.push(record.event.data)
     } else if (event.section === 'balances' && event.method === 'Slashed') {
       assert(client.api.events.balances.Slashed.is(event))
-      balancesSlashEvents.push(record)
+      balancesSlashEvents.push(record.event.data)
     }
   }
 


### PR DESCRIPTION
Closes #252.

The failing CI pipeline's logs don't show the snapshot diffs; I'm guessing the stored events include unnecessary information.