### PR TITLE
Update test to setting metadata to reflect new event

### DIFF
--- a/packages/kusama/src/__snapshots__/kusama.nominationPools.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/kusama.nominationPools.e2e.test.ts.snap
@@ -454,7 +454,6 @@ exports[`Kusama Nomination Pools > nomination pool metadata test > set metadata 
   {
     "data": {
       "caller": "HNZata7iMYWmk5RvZRTiAsSDhV8366zq2YGb3tLH5Upf74F",
-      "poolId": "(rounded 220)",
     },
     "method": "MetadataUpdated",
     "section": "nominationPools",

--- a/packages/polkadot/src/__snapshots__/polkadot.nominationPools.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadot.nominationPools.e2e.test.ts.snap
@@ -454,7 +454,6 @@ exports[`Polkadot Nomination Pools > nomination pool metadata test > set metadat
   {
     "data": {
       "caller": "15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5",
-      "poolId": "(rounded 330)",
     },
     "method": "MetadataUpdated",
     "section": "nominationPools",

--- a/packages/shared/src/nomination-pools.ts
+++ b/packages/shared/src/nomination-pools.ts
@@ -660,8 +660,9 @@ async function nominationPoolSetMetadataTest<
 
   await client.dev.newBlock()
 
-  /// TODO: no events are emitted here pending a PR to `pallet_nomination_pools`.
-  await checkEvents(setMetadataEvents, 'nominationPools').toMatchSnapshot('set metadata events')
+  await checkEvents(setMetadataEvents, 'nominationPools')
+    .redact({ removeKeys: /poolId/ })
+    .toMatchSnapshot('set metadata events')
 
   /// Check the set metadata
 


### PR DESCRIPTION
After https://github.com/paritytech/polkadot-sdk/pull/7377, `nomination_pools::set_metadata` now emits an event.
The `pool_id` field of that event needs to be redacted, as it is unstable.