### PR TITLE
Remove leftover time-sensitive datum from scheduler E2E test snapshot

### DIFF
--- a/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/kusama.scheduler.e2e.test.ts.snap
@@ -143,7 +143,7 @@ exports[`Kusama Scheduler > priority-based execution of weighted tasks works cor
   },
   {
     "data": {
-      "when": "(rounded 30000000)",
+      "when": "(redacted)",
     },
     "method": "AgendaIncomplete",
     "section": "scheduler",

--- a/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadot.scheduler.e2e.test.ts.snap
@@ -143,7 +143,7 @@ exports[`Polkadot Scheduler > priority-based execution of weighted tasks works c
   },
   {
     "data": {
-      "when": "(rounded 27000000)",
+      "when": "(redacted)",
     },
     "method": "AgendaIncomplete",
     "section": "scheduler",

--- a/packages/shared/src/scheduler.ts
+++ b/packages/shared/src/scheduler.ts
@@ -1002,7 +1002,7 @@ export async function schedulePriorityWeightedTasks<
   // Check events - there should only be one execution
   await checkSystemEvents(client, 'scheduler', { section: 'balances', method: 'TotalIssuanceForced' })
     .redact({
-      redactKeys: /new|old|task/,
+      redactKeys: /new|old|task|when/,
     })
     .toMatchSnapshot('events for priority weighted tasks execution')
 


### PR DESCRIPTION
Follow-up to #365 .