### PR TITLE
Fix minor points for some AHM E2E scheduler tests

### DIFF
--- a/packages/kusama/src/kusama.staking.e2e.test.ts
+++ b/packages/kusama/src/kusama.staking.e2e.test.ts
@@ -1,5 +1,5 @@
 import { kusama } from '@e2e-test/networks/chains'
-import { fullStakingTests, type RelayTestConfig, registerTestTree } from '@e2e-test/shared'
+import { completeStakingE2ETests, type RelayTestConfig, registerTestTree } from '@e2e-test/shared'
 
 const testConfig: RelayTestConfig = {
   testSuiteName: 'Kusama Staking',
@@ -7,4 +7,4 @@ const testConfig: RelayTestConfig = {
   blockProvider: 'Local',
 }
 
-registerTestTree(fullStakingTests(kusama, testConfig))
+registerTestTree(completeStakingE2ETests(kusama, testConfig))

--- a/packages/polkadot/src/polkadot.staking.e2e.test.ts
+++ b/packages/polkadot/src/polkadot.staking.e2e.test.ts
@@ -1,5 +1,5 @@
 import { polkadot } from '@e2e-test/networks/chains'
-import { fullStakingTests, type RelayTestConfig, registerTestTree } from '@e2e-test/shared'
+import { completeStakingE2ETests, type RelayTestConfig, registerTestTree } from '@e2e-test/shared'
 
 const testConfig: RelayTestConfig = {
   testSuiteName: 'Polkadot Staking',
@@ -7,4 +7,4 @@ const testConfig: RelayTestConfig = {
   blockProvider: 'Local',
 }
 
-registerTestTree(fullStakingTests(polkadot, testConfig))
+registerTestTree(completeStakingE2ETests(polkadot, testConfig))

--- a/packages/shared/src/scheduler.ts
+++ b/packages/shared/src/scheduler.ts
@@ -1423,7 +1423,14 @@ export async function schedulePriorityWeightedTasks<
     // serviced.
     // `currBlockNumber` advanced by `offset` in the meantime, so `- 1` is the correct value.
     expect(finalIncompleteSince.isSome).toBeTruthy()
-    expect(finalIncompleteSince.unwrap().toNumber()).toBe(currBlockNumber - 1)
+    match(testConfig.blockProvider)
+      .with('Local', async () => {
+        expect(finalIncompleteSince.unwrap().toNumber()).toBe(currBlockNumber + 1)
+      })
+      .with('NonLocal', async () => {
+        expect(finalIncompleteSince.unwrap().toNumber()).toBe(currBlockNumber - 1)
+      })
+      .exhaustive()
   } else {
     expect(finalIncompleteSince.isNone).toBeTruthy()
   }

--- a/packages/shared/src/scheduler.ts
+++ b/packages/shared/src/scheduler.ts
@@ -1417,8 +1417,13 @@ export async function schedulePriorityWeightedTasks<
   // Verify `incompleteSince` has been unset
   const finalIncompleteSince = await client.api.query.scheduler.incompleteSince()
   if (chain.name.toLowerCase().includes('kusama')) {
+    // Kusama is using a new version of the scheduler pallet prepared for general applicability, including in
+    // post-AHM asset hubs.
+    // It always sets `incompleteSince` to `n + 1`, where `n` is the block in which the agenda was last
+    // serviced.
+    // `currBlockNumber` advanced by `offset` in the meantime, so `- 1` is the correct value.
     expect(finalIncompleteSince.isSome).toBeTruthy()
-    expect(finalIncompleteSince.unwrap().toNumber()).toBe(currBlockNumber + 1)
+    expect(finalIncompleteSince.unwrap().toNumber()).toBe(currBlockNumber - 1)
   } else {
     expect(finalIncompleteSince.isNone).toBeTruthy()
   }

--- a/packages/shared/src/staking.ts
+++ b/packages/shared/src/staking.ts
@@ -2163,6 +2163,9 @@ export function baseStakingE2ETests<
   }
 }
 
+/**
+ * Tests to fast unstake pallet.
+ */
 export function fastUnstakeTests<
   TCustom extends Record<string, unknown> | undefined,
   TInitStorages extends Record<string, Record<string, any>> | undefined,
@@ -2180,7 +2183,10 @@ export function fastUnstakeTests<
   }
 }
 
-export function stakingTests<
+/**
+ * Staking E2E test tree - contains base tests to pallet functionality, as well as slashing tests.
+ */
+export function fullStakingE2ETests<
   TCustom extends Record<string, unknown> | undefined,
   TInitStorages extends Record<string, Record<string, any>> | undefined,
 >(chain: Chain<TCustom, TInitStorages>, testConfig: TestConfig): RootTestTree {
@@ -2194,7 +2200,13 @@ export function stakingTests<
   }
 }
 
-export function fullStakingTests<
+/**
+ * Complete staking E2E test tree; contains
+ * 1. base tests
+ * 2. slashing tests
+ * 3. fast unstake tests
+ */
+export function completeStakingE2ETests<
   TCustom extends Record<string, unknown> | undefined,
   TInitStorages extends Record<string, Record<string, any>> | undefined,
 >(chain: Chain<TCustom, TInitStorages>, testConfig: TestConfig): RootTestTree {

--- a/packages/shared/src/staking.ts
+++ b/packages/shared/src/staking.ts
@@ -496,6 +496,7 @@ async function forceUnstakeTest<
   if (minValidatorBond === 0n) {
     minValidatorBond = ed * 10n ** 5n
   }
+  const minValidatorCommission = (await client.api.query.staking.minCommission()).toBigInt()
 
   await client.dev.setStorage({
     System: {
@@ -519,7 +520,7 @@ async function forceUnstakeTest<
 
   /// Express intent to validate as Alice, and nominate as Bob
 
-  const validateTx = client.api.tx.staking.validate({ commission: 10e6, blocked: false })
+  const validateTx = client.api.tx.staking.validate({ commission: minValidatorCommission, blocked: false })
   await sendTransaction(validateTx.signAsync(alice))
 
   await client.dev.newBlock()


### PR DESCRIPTION
The scheduler E2E tests have already been reworked to work both on current relay chains, or post-migration Asset Hub runtimes through #355 .

This PR adds a minor fix to a test for the `scheduler.incompleteSince` mechanism to allow it to run on all of
1. Polkadot,
2. Kusama (which is running a newer version of the pallet, containing changes and improvements for the AHM), and
3. Asset Hubs, too