### PR TITLE
Proxy E2E tests, call filtering: check for correct pallet in fast unstake action

### DIFF
--- a/packages/kusama/src/__snapshots__/kusama.proxy.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/kusama.proxy.e2e.test.ts.snap
@@ -1578,6 +1578,25 @@ exports[`Kusama Proxy full tests (includes call filtering) > filtering tests for
 ]
 `;
 
+exports[`Kusama Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for Staking > events for proxy type Staking, pallet fast_unstake, call register_fast_unstake 1`] = `
+[
+  {
+    "data": {
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x00000000",
+            "index": 42,
+          },
+        },
+      },
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
 exports[`Kusama Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for Staking > events for proxy type Staking, pallet nomination_pools, call chill 1`] = `
 [
   {

--- a/packages/kusama/src/__snapshots__/kusama.proxy.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/kusama.proxy.e2e.test.ts.snap
@@ -1636,25 +1636,6 @@ exports[`Kusama Proxy full tests (includes call filtering) > filtering tests for
 ]
 `;
 
-exports[`Kusama Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for Staking > events for proxy type Staking, pallet staking, call register_fast_unstake 1`] = `
-[
-  {
-    "data": {
-      "result": {
-        "Err": {
-          "Module": {
-            "error": "0x00000000",
-            "index": 42,
-          },
-        },
-      },
-    },
-    "method": "ProxyExecuted",
-    "section": "proxy",
-  },
-]
-`;
-
 exports[`Kusama Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for Staking > events for proxy type Staking, pallet utility, call batch 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/polkadot.proxy.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadot.proxy.e2e.test.ts.snap
@@ -1402,6 +1402,25 @@ exports[`Polkadot Proxy full tests (includes call filtering) > filtering tests f
 ]
 `;
 
+exports[`Polkadot Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for Staking > events for proxy type Staking, pallet fast_unstake, call register_fast_unstake 1`] = `
+[
+  {
+    "data": {
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x00000000",
+            "index": 40,
+          },
+        },
+      },
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
 exports[`Polkadot Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for Staking > events for proxy type Staking, pallet nomination_pools, call chill 1`] = `
 [
   {

--- a/packages/polkadot/src/__snapshots__/polkadot.proxy.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/polkadot.proxy.e2e.test.ts.snap
@@ -1460,25 +1460,6 @@ exports[`Polkadot Proxy full tests (includes call filtering) > filtering tests f
 ]
 `;
 
-exports[`Polkadot Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for Staking > events for proxy type Staking, pallet staking, call register_fast_unstake 1`] = `
-[
-  {
-    "data": {
-      "result": {
-        "Err": {
-          "Module": {
-            "error": "0x00000000",
-            "index": 40,
-          },
-        },
-      },
-    },
-    "method": "ProxyExecuted",
-    "section": "proxy",
-  },
-]
-`;
-
 exports[`Polkadot Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for Staking > events for proxy type Staking, pallet utility, call batch 1`] = `
 [
   {

--- a/packages/shared/src/proxy.ts
+++ b/packages/shared/src/proxy.ts
@@ -398,7 +398,7 @@ class ProxyActionBuilderImpl<
     const fastUnstakeCalls: ProxyAction[] = []
     if (this.client.api.tx.fastUnstake) {
       fastUnstakeCalls.push({
-        pallet: 'staking',
+        pallet: 'fast_unstake',
         extrinsic: 'register_fast_unstake',
         call: this.client.api.tx.fastUnstake.registerFastUnstake(),
       })

--- a/packages/shared/src/proxy.ts
+++ b/packages/shared/src/proxy.ts
@@ -396,7 +396,7 @@ class ProxyActionBuilderImpl<
 
   buildFastUnstakeAction(): ProxyAction[] {
     const fastUnstakeCalls: ProxyAction[] = []
-    if (this.client.api.tx.staking) {
+    if (this.client.api.tx.fastUnstake) {
       fastUnstakeCalls.push({
         pallet: 'staking',
         extrinsic: 'register_fast_unstake',


### PR DESCRIPTION
It requires the `fast_unstake` pallet, and not `staking`.