### PR TITLE
Add tests for PreImage (continued)

### DIFF
--- a/packages/kusama/src/__snapshots__/assetHubKusama.preimage.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/assetHubKusama.preimage.e2e.test.ts.snap
@@ -1,5 +1,33 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Kusama Asset Hub PreImage > Kusama Asset Hub PreImage > preimage tests > preimage empty test > note empty preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
+exports[`Kusama Asset Hub PreImage > Kusama Asset Hub PreImage > preimage tests > preimage empty test > unnote empty preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Cleared",
+    "section": "preimage",
+  },
+]
+`;
+
+exports[`Kusama Asset Hub PreImage > Kusama Asset Hub PreImage > preimage tests > preimage ensure updated test (fees due) > ensure updated preimage events 1`] = `[]`;
+
+exports[`Kusama Asset Hub PreImage > Kusama Asset Hub PreImage > preimage tests > preimage ensure updated test (no fees due) > ensure updated preimage events 1`] = `[]`;
+
 exports[`Kusama Asset Hub PreImage > Kusama Asset Hub PreImage > preimage tests > preimage single note and unnote test > note preimage events 1`] = `
 [
   {
@@ -23,3 +51,47 @@ exports[`Kusama Asset Hub PreImage > Kusama Asset Hub PreImage > preimage tests 
   },
 ]
 `;
+
+exports[`Kusama Asset Hub PreImage > failure tests > preimage oversized test > note oversized preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
+exports[`Kusama Asset Hub PreImage > failure tests > preimage repeated note and unnote test > note preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
+exports[`Kusama Asset Hub PreImage > failure tests > preimage repeated note and unnote test > repeat note preimage events 1`] = `[]`;
+
+exports[`Kusama Asset Hub PreImage > failure tests > preimage repeated note and unnote test > repeat unnote preimage events 1`] = `[]`;
+
+exports[`Kusama Asset Hub PreImage > failure tests > preimage repeated note and unnote test > unnote preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Cleared",
+    "section": "preimage",
+  },
+]
+`;
+
+exports[`Kusama Asset Hub PreImage > failure tests > preimage single request and unrequest test as non-root > request preimage events 1`] = `[]`;
+
+exports[`Kusama Asset Hub PreImage > failure tests > preimage single request and unrequest test as non-root > unrequest preimage events 1`] = `[]`;

--- a/packages/polkadot/src/__snapshots__/assetHubPolkadot.preimage.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/assetHubPolkadot.preimage.e2e.test.ts.snap
@@ -1,5 +1,33 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Polkadot Asset Hub PreImage > Polkadot Asset Hub PreImage > preimage tests > preimage empty test > note empty preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
+exports[`Polkadot Asset Hub PreImage > Polkadot Asset Hub PreImage > preimage tests > preimage empty test > unnote empty preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Cleared",
+    "section": "preimage",
+  },
+]
+`;
+
+exports[`Polkadot Asset Hub PreImage > Polkadot Asset Hub PreImage > preimage tests > preimage ensure updated test (fees due) > ensure updated preimage events 1`] = `[]`;
+
+exports[`Polkadot Asset Hub PreImage > Polkadot Asset Hub PreImage > preimage tests > preimage ensure updated test (no fees due) > ensure updated preimage events 1`] = `[]`;
+
 exports[`Polkadot Asset Hub PreImage > Polkadot Asset Hub PreImage > preimage tests > preimage single note and unnote test > note preimage events 1`] = `
 [
   {
@@ -23,3 +51,47 @@ exports[`Polkadot Asset Hub PreImage > Polkadot Asset Hub PreImage > preimage te
   },
 ]
 `;
+
+exports[`Polkadot Asset Hub PreImage > failure tests > preimage oversized test > note oversized preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
+exports[`Polkadot Asset Hub PreImage > failure tests > preimage repeated note and unnote test > note preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
+exports[`Polkadot Asset Hub PreImage > failure tests > preimage repeated note and unnote test > repeat note preimage events 1`] = `[]`;
+
+exports[`Polkadot Asset Hub PreImage > failure tests > preimage repeated note and unnote test > repeat unnote preimage events 1`] = `[]`;
+
+exports[`Polkadot Asset Hub PreImage > failure tests > preimage repeated note and unnote test > unnote preimage events 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Cleared",
+    "section": "preimage",
+  },
+]
+`;
+
+exports[`Polkadot Asset Hub PreImage > failure tests > preimage single request and unrequest test as non-root > request preimage events 1`] = `[]`;
+
+exports[`Polkadot Asset Hub PreImage > failure tests > preimage single request and unrequest test as non-root > unrequest preimage events 1`] = `[]`;

--- a/packages/shared/src/multisig.proxy.ts
+++ b/packages/shared/src/multisig.proxy.ts
@@ -5,7 +5,6 @@ import { type Client, setupBalances, setupNetworks, verifyPureProxy } from '@e2e
 
 import type { KeyringPair } from '@polkadot/keyring/types'
 import type { AccountId32 } from '@polkadot/types/interfaces/runtime'
-import type { FrameSystemAccountInfo } from '@polkadot/types/lookup'
 import type { U8aFixed } from '@polkadot/types-codec'
 import { encodeAddress } from '@polkadot/util-crypto'
 
@@ -16,6 +15,8 @@ import {
   check,
   checkEvents,
   getBlockNumber,
+  getFreeFunds,
+  getReservedFunds,
   sortAddressesByBytes,
   type TestConfig,
 } from './helpers/index.js'
@@ -84,22 +85,6 @@ async function getAndVerifyMultisigEventData(
   const multisigCallHash = newMultisigEventData.callHash
 
   return [multisigAddress, multisigExtrinsicIndex, multisigCallHash]
-}
-
-/**
- * Get the free funds of an account.
- */
-async function getFreeFunds(client: Client<any, any>, address: any): Promise<number> {
-  const account = (await client.api.query.system.account(address)) as FrameSystemAccountInfo
-  return account.data.free.toNumber()
-}
-
-/**
- * Get the reserved funds of an account.
- */
-async function getReservedFunds(client: Client<any, any>, address: any): Promise<number> {
-  const account = (await client.api.query.system.account(address)) as FrameSystemAccountInfo
-  return account.data.reserved.toNumber()
 }
 
 /**


### PR DESCRIPTION
Add additional tests which verify PreImage behavior:
- 1) A manager account requests a preimage hash once then unrequests it multiple times (added additional checks)
- 2) Check the noting and unnoting of empty images
- 3) Check the noting and unnoting of oversized images
- 4) Check the repeated noting and unnoting of the same preimage
- 5) Check preimage behavior when requesting, noting, unrequesting and unnoting occur in different orders
- 6) Check the "ensure_updated" extrinsic applies fees depending on the update ratio

Several utility functions have been moved to the helpers file as they are shared with other test files.

This is a continuation of the PR: https://github.com/open-web3-stack/polkadot-ecosystem-tests/pull/470.
Also address outstanding comments from the original PR.

Closes #453.