### PR TITLE
Bump PJS to 16.5.1

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -5,9 +5,9 @@
 		"@acala-network/chopsticks": "^1.2.3",
 		"@acala-network/chopsticks-testing": "^1.2.3",
 		"@e2e-test/networks": "workspace:*",
-		"@polkadot/api": "^16.4.9",
-		"@polkadot/types": "^16.4.9",
-		"@polkadot/types-augment": "^16.4.9"
+		"@polkadot/api": "^16.5.1",
+		"@polkadot/types": "^16.5.1",
+		"@polkadot/types-augment": "^16.5.1"
 	},
 	"main": "./dist/cjs/index.js",
 	"module": "./dist/esm/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -261,9 +261,9 @@ __metadata:
     "@acala-network/chopsticks": "npm:^1.2.3"
     "@acala-network/chopsticks-testing": "npm:^1.2.3"
     "@e2e-test/networks": "workspace:*"
-    "@polkadot/api": "npm:^16.4.9"
-    "@polkadot/types": "npm:^16.4.9"
-    "@polkadot/types-augment": "npm:^16.4.9"
+    "@polkadot/api": "npm:^16.5.1"
+    "@polkadot/types": "npm:^16.5.1"
+    "@polkadot/types-augment": "npm:^16.5.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Supersedes #465, which was failing due to spurious `yarn lint` issues.