### PR TITLE
Change Kusama Asset Hub endpoint

### DIFF
--- a/packages/networks/src/chains/assethub.ts
+++ b/packages/networks/src/chains/assethub.ts
@@ -74,7 +74,7 @@ export const assetHubPolkadot = defineChain({
 
 export const assetHubKusama = defineChain({
   name: 'assetHubKusama',
-  endpoint: 'wss://sys.ibp.network/asset-hub-kusama',
+  endpoint: 'wss://asset-hub-kusama-rpc.n.dwellir.com',
   paraId: 1000,
   networkGroup: 'kusama',
   custom: custom.assetHubKusama,


### PR DESCRIPTION
The IBP one being used has been causing some tests to timeout frequently.