### PR TITLE
Reenable Kusama system tests that required `preimage` on relay

### DIFF
--- a/packages/kusama/src/assetHubKusama.system.e2e.test.ts
+++ b/packages/kusama/src/assetHubKusama.system.e2e.test.ts
@@ -1,11 +1,15 @@
-import { assetHubKusama } from '@e2e-test/networks/chains'
-import { registerTestTree, systemE2ETestsForParaWithScheduler, type TestConfig } from '@e2e-test/shared'
-
-// TODO: Uncomment after Kusama 2.0+ release due to polkadot-fellows/runtimes#957
-// registerTestTree(systemE2ETestsViaRemoteScheduler(kusama, assetHubKusama, testConfig))
+import { assetHubKusama, kusama } from '@e2e-test/networks/chains'
+import {
+  registerTestTree,
+  systemE2ETestsForParaWithScheduler,
+  systemE2ETestsViaRemoteScheduler,
+  type TestConfig,
+} from '@e2e-test/shared'
 
 const testConfig: TestConfig = {
   testSuiteName: 'Kusama AssetHub System',
 }
+
+registerTestTree(systemE2ETestsViaRemoteScheduler(kusama, assetHubKusama, testConfig))
 
 registerTestTree(systemE2ETestsForParaWithScheduler(assetHubKusama, testConfig))

--- a/packages/kusama/src/bridgeHubKusama.system.e2e.test.ts
+++ b/packages/kusama/src/bridgeHubKusama.system.e2e.test.ts
@@ -1,11 +1,10 @@
-import { assetHubKusama, bridgeHubKusama } from '@e2e-test/networks/chains'
+import { assetHubKusama, bridgeHubKusama, kusama } from '@e2e-test/networks/chains'
 import { registerTestTree, systemE2ETestsViaRemoteScheduler, type TestConfig } from '@e2e-test/shared'
 
 const testConfig: TestConfig = {
   testSuiteName: 'Kusama BridgeHub System',
 }
 
-// TODO: Uncomment after Kusama 2.0+ release due to polkadot-fellows/runtimes#957
-// registerTestTree(systemE2ETestsViaRemoteScheduler(kusama, bridgeHubKusama, testConfig))
+registerTestTree(systemE2ETestsViaRemoteScheduler(kusama, bridgeHubKusama, testConfig))
 
 registerTestTree(systemE2ETestsViaRemoteScheduler(assetHubKusama, bridgeHubKusama, testConfig))

--- a/packages/kusama/src/coretimeKusama.system.e2e.test.ts
+++ b/packages/kusama/src/coretimeKusama.system.e2e.test.ts
@@ -1,11 +1,10 @@
-import { assetHubKusama, coretimeKusama } from '@e2e-test/networks/chains'
+import { assetHubKusama, coretimeKusama, kusama } from '@e2e-test/networks/chains'
 import { registerTestTree, systemE2ETestsViaRemoteScheduler, type TestConfig } from '@e2e-test/shared'
 
 const testConfig: TestConfig = {
   testSuiteName: 'Kusama Coretime System',
 }
 
-// TODO: Uncomment after Kusama 2.0+ release due to polkadot-fellows/runtimes#957
-// registerTestTree(systemE2ETestsViaRemoteScheduler(kusama, coretimeKusama, testConfig))
+registerTestTree(systemE2ETestsViaRemoteScheduler(kusama, coretimeKusama, testConfig))
 
 registerTestTree(systemE2ETestsViaRemoteScheduler(assetHubKusama, coretimeKusama, testConfig))

--- a/packages/kusama/src/encointerKusama.system.e2e.test.ts
+++ b/packages/kusama/src/encointerKusama.system.e2e.test.ts
@@ -1,11 +1,10 @@
-import { assetHubKusama, encointerKusama } from '@e2e-test/networks/chains'
+import { assetHubKusama, encointerKusama, kusama } from '@e2e-test/networks/chains'
 import { registerTestTree, systemE2ETestsViaRemoteScheduler, type TestConfig } from '@e2e-test/shared'
 
 const testConfig: TestConfig = {
   testSuiteName: 'Kusama Encointer System',
 }
 
-// TODO: Uncomment after Kusama 2.0+ release due to polkadot-fellows/runtimes#957
-// registerTestTree(systemE2ETestsViaRemoteScheduler(kusama, encointerKusama, testConfig))
+registerTestTree(systemE2ETestsViaRemoteScheduler(kusama, encointerKusama, testConfig))
 
 registerTestTree(systemE2ETestsViaRemoteScheduler(assetHubKusama, encointerKusama, testConfig))

--- a/packages/kusama/src/kusama.system.e2e.test.ts
+++ b/packages/kusama/src/kusama.system.e2e.test.ts
@@ -1,11 +1,10 @@
 import { assetHubKusama, kusama } from '@e2e-test/networks/chains'
-import { registerTestTree, systemE2ETestsViaRemoteScheduler, type TestConfig } from '@e2e-test/shared'
+import { registerTestTree, systemE2ETests, systemE2ETestsViaRemoteScheduler, type TestConfig } from '@e2e-test/shared'
 
 const testConfig: TestConfig = {
   testSuiteName: 'Kusama System',
 }
 
-// TODO: Uncomment after Kusama 2.0+ release due to polkadot-fellows/runtimes#957
-// registerTestTree(systemE2ETests(kusama, testConfig))
+registerTestTree(systemE2ETests(kusama, testConfig))
 
 registerTestTree(systemE2ETestsViaRemoteScheduler(assetHubKusama, kusama, testConfig))

--- a/packages/kusama/src/peopleKusama.system.e2e.test.ts
+++ b/packages/kusama/src/peopleKusama.system.e2e.test.ts
@@ -1,11 +1,10 @@
-import { assetHubKusama, peopleKusama } from '@e2e-test/networks/chains'
+import { assetHubKusama, kusama, peopleKusama } from '@e2e-test/networks/chains'
 import { registerTestTree, systemE2ETestsViaRemoteScheduler, type TestConfig } from '@e2e-test/shared'
-
-// TODO: Uncomment after Kusama 2.0+ release due to polkadot-fellows/runtimes#957
-// registerTestTree(systemE2ETestsViaRemoteScheduler(kusama, peopleKusama, testConfig))
 
 const testConfig: TestConfig = {
   testSuiteName: 'Kusama People System',
 }
+
+registerTestTree(systemE2ETestsViaRemoteScheduler(kusama, peopleKusama, testConfig))
 
 registerTestTree(systemE2ETestsViaRemoteScheduler(assetHubKusama, peopleKusama, testConfig))

--- a/packages/shared/src/nomination-pools.ts
+++ b/packages/shared/src/nomination-pools.ts
@@ -426,8 +426,6 @@ async function nominationPoolLifecycleTest<
 
   await client.dev.newBlock()
 
-  // TODO: `nominate` does not emit any events from `staking` or `nominationPools` as of
-  // Jan. 2025. [#7377](https://github.com/paritytech/polkadot-sdk/pull/7377) will fix this.
   await checkEvents(nominateEvents, 'staking', 'nominationPools', 'system')
     .redact({ removeKeys: /poolId|stash/ })
     .toMatchSnapshot('nomination pool validator selection events')


### PR DESCRIPTION
Closes #526 .