### PR TITLE
Fix staking and proxy tests for polkadot-sdk stable2512

### DIFF
--- a/packages/shared/src/postAhmFiltering.ts
+++ b/packages/shared/src/postAhmFiltering.ts
@@ -69,6 +69,7 @@ export async function stakingCallsFilteredTest<
       { Noop: null },
       { Noop: null },
       { Noop: null },
+      { Noop: null },
     ),
     // 23
     client.api.tx.staking.chillOther(testAccounts.alice.address),

--- a/packages/shared/src/proxy.ts
+++ b/packages/shared/src/proxy.ts
@@ -1516,17 +1516,13 @@ export async function addRemoveProxyTest<
   // Remove delay-having proxies
 
   const removeProxiesTx = client.api.tx.proxy.removeProxies()
-  await sendTransaction(removeProxiesTx.signAsync(alice))
+  const removeProxiesEvents = await sendTransaction(removeProxiesTx.signAsync(alice))
 
   await client.dev.newBlock()
 
-  // TODO: `remove_proxies` emits no events; when/if it ever does, this'll fail.
-  const events = await client.api.query.system.events()
-  const removeProxiesEvent = events.find((record) => {
-    const { event } = record
-    return event.section === 'proxy'
-  })
-  expect(removeProxiesEvent).toBeUndefined()
+  await checkEvents(removeProxiesEvents, { section: 'proxy', method: 'ProxyRemoved' }).toMatchSnapshot(
+    'events when removing all proxies from Alice',
+  )
 
   proxyData = await client.api.query.proxy.proxies(alice.address)
   proxies = proxyData[0]

--- a/packages/shared/src/staking.ts
+++ b/packages/shared/src/staking.ts
@@ -732,6 +732,7 @@ async function setStakingConfigsTest<
   const preChillThreshold = (await client.api.query.staking.chillThreshold()).unwrapOr(tenPercent).toNumber()
   const preMinCommission = (await client.api.query.staking.minCommission()).toNumber()
   const preMaxStakedRewards = (await client.api.query.staking.maxStakedRewards()).unwrapOr(tenPercent).toNumber()
+  const preAreNominatorsSlashable = (await client.api.query.staking.areNominatorsSlashable()).toPrimitive() as boolean
 
   const setStakingConfigsCall = (inc: number) =>
     client.api.tx.staking.setStakingConfigs(
@@ -742,6 +743,7 @@ async function setStakingConfigsTest<
       { Set: preChillThreshold + inc },
       { Set: preMinCommission + inc },
       { Set: preMaxStakedRewards + inc },
+      { Set: !preAreNominatorsSlashable },
     )
 
   ///
@@ -803,6 +805,7 @@ async function setStakingConfigsTest<
   const postChillThreshold = (await client.api.query.staking.chillThreshold()).unwrap().toNumber()
   const postMinCommission = (await client.api.query.staking.minCommission()).toNumber()
   const postMaxStakedRewards = (await client.api.query.staking.maxStakedRewards()).unwrap().toNumber()
+  const postAreNominatorsSlashable = (await client.api.query.staking.areNominatorsSlashable()).toPrimitive() as boolean
 
   const [setStakingConfigsSuccess] = events.filter((record) => {
     const { event } = record
@@ -818,6 +821,7 @@ async function setStakingConfigsTest<
   expect(postChillThreshold).toBe(preChillThreshold + inc)
   expect(postMinCommission).toBe(preMinCommission + inc)
   expect(postMaxStakedRewards).toBe(preMaxStakedRewards + inc)
+  expect(postAreNominatorsSlashable).toBe(!preAreNominatorsSlashable)
 }
 
 /**
@@ -890,6 +894,7 @@ async function forceApplyValidatorCommissionTest<
     { Noop: null },
     { Noop: null },
     { Set: newCommission },
+    { Noop: null },
     { Noop: null },
   )
 
@@ -1086,6 +1091,7 @@ async function chillOtherTest<
     { Remove: null },
     { Noop: null },
     { Noop: null },
+    { Noop: null },
   )
 
   await scheduleInlineCallWithOrigin(
@@ -1166,9 +1172,9 @@ async function chillOtherTest<
       [setNominatorCount, setValidatorCount],
     ]) {
       for (const chillThreshold of [remove, chillThresholdSet]) {
-        const [a, b, c, d, e, f, g] = [...bondLimits, ...countLimits, chillThreshold, ...Array(2).fill(noop)]
+        const [a, b, c, d, e, f, g, h] = [...bondLimits, ...countLimits, chillThreshold, ...Array(3).fill(noop)]
 
-        setStakingConfigsCalls.push(client.api.tx.staking.setStakingConfigs(a, b, c, d, e, f, g))
+        setStakingConfigsCalls.push(client.api.tx.staking.setStakingConfigs(a, b, c, d, e, f, g, h))
       }
     }
   }


### PR DESCRIPTION
(this PR is courtesy of @sigurpol; see issue body for reason this PR was made against `runtimes-master` and not `master`).

- setStakingConfigs gained an 8th parameter (are_nominators_slashable)
- removeProxies now emits ProxyRemoved events per removed proxy.

Fix related tests to be SDK's stable2512 compliant.

Will close #530 .