### PR TITLE
fixed max child bounties count

### DIFF
--- a/packages/shared/src/childBounties.ts
+++ b/packages/shared/src/childBounties.ts
@@ -2149,12 +2149,11 @@ export async function childBountyTooManyChildBountiesErrorTest<
   // ===== SECTION 2: Set parent child bounties count to exceed maxActiveChildBountyCount =====
 
   const maxActiveChildBountyCount = client.api.consts.childBounties.maxActiveChildBountyCount.toNumber()
-  const greaterThanMaxActiveChildBountyCount = maxActiveChildBountyCount + 1 // TODO : after the bug is fixed in child_bounties, this should be removed
 
   // set parent child bounties count to maxActiveChildBountyCount
   await client.dev.setStorage({
     ChildBounties: {
-      parentChildBounties: [[[bountyIndex], greaterThanMaxActiveChildBountyCount]],
+      parentChildBounties: [[[bountyIndex], maxActiveChildBountyCount]],
     },
   })
 
@@ -2162,7 +2161,7 @@ export async function childBountyTooManyChildBountiesErrorTest<
 
   // ensure the parent child bounties count is greater than maxActiveChildBountyCount
   const parentChildBountiesCount = await getParentChildBountiesCount(client, bountyIndex)
-  expect(parentChildBountiesCount).toBe(greaterThanMaxActiveChildBountyCount)
+  expect(parentChildBountiesCount).toBe(maxActiveChildBountyCount)
 
   // ===== SECTION 3: Attempt to create child bounty after setting parent child bounties count to maxActiveChildBountyCount =====
 


### PR DESCRIPTION
## Description

This PR removes the workaround for the child bounties max count bug and updates the test to use the correct `maxActiveChildBountyCount` value directly.

## Changes

- Removed the `greaterThanMaxActiveChildBountyCount` variable that unnecessarily incremented the max count
- Removed the TODO comment indicating the bug needed fixing
- Updated the test expectations to correctly validate behavior at `maxActiveChildBountyCount` (not above it)

## Why This Matters

The child_bounties pallet had a bug where it didn't properly enforce the `maxActiveChildBountyCount` constraint. This workaround was added to test around that issue. Now that the underlying bug has been fixed in the child_bounties release, the test can be simplified to use the correct limit value.

## Related Issues

Fixes the TODO from the child_bounties create release fix.
