### PR TITLE
Replace `asyncBacking` flag with `relayBlocksPerParaBlock` per-chain property

### DIFF
--- a/packages/networks/src/chains/acala.ts
+++ b/packages/networks/src/chains/acala.ts
@@ -92,7 +92,7 @@ export const acala = defineChain({
     addressEncoding: 10,
     proxyBlockProvider: 'Local',
     schedulerBlockProvider: 'Local',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: acalaFeeExtractor,
   },
 })
@@ -108,7 +108,7 @@ export const karura = defineChain({
     addressEncoding: 8,
     proxyBlockProvider: 'Local',
     schedulerBlockProvider: 'Local',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: acalaFeeExtractor,
   },
 })

--- a/packages/networks/src/chains/assethub.ts
+++ b/packages/networks/src/chains/assethub.ts
@@ -206,7 +206,7 @@ const assetHubProperties = (addressEncoding: number) =>
     addressEncoding,
     proxyBlockProvider: 'NonLocal',
     schedulerBlockProvider: 'NonLocal',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 3,
     feeExtractor: standardFeeExtractor,
   }) as const
 

--- a/packages/networks/src/chains/assethub.ts
+++ b/packages/networks/src/chains/assethub.ts
@@ -206,7 +206,7 @@ const assetHubProperties = (addressEncoding: number) =>
     addressEncoding,
     proxyBlockProvider: 'NonLocal',
     schedulerBlockProvider: 'NonLocal',
-    relayBlocksPerParaBlock: 3,
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   }) as const
 

--- a/packages/networks/src/chains/astar.ts
+++ b/packages/networks/src/chains/astar.ts
@@ -53,7 +53,7 @@ export const astar = defineChain({
   properties: {
     addressEncoding: 5,
     schedulerBlockProvider: 'Local',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })
@@ -68,7 +68,7 @@ export const shiden = defineChain({
   properties: {
     addressEncoding: 5,
     schedulerBlockProvider: 'Local',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })

--- a/packages/networks/src/chains/bifrost.ts
+++ b/packages/networks/src/chains/bifrost.ts
@@ -45,7 +45,7 @@ export const bifrostPolkadot = defineChain({
   properties: {
     addressEncoding: 0,
     schedulerBlockProvider: 'Local',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })
@@ -60,7 +60,7 @@ export const bifrostKusama = defineChain({
   properties: {
     addressEncoding: 0,
     schedulerBlockProvider: 'Local',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })

--- a/packages/networks/src/chains/bridgehub.ts
+++ b/packages/networks/src/chains/bridgehub.ts
@@ -34,7 +34,7 @@ export const bridgeHubPolkadot = defineChain({
     addressEncoding: 0,
     proxyBlockProvider: 'Local',
     schedulerBlockProvider: 'NonLocal',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })
@@ -50,7 +50,7 @@ export const bridgeHubKusama = defineChain({
     addressEncoding: 2,
     proxyBlockProvider: 'Local',
     schedulerBlockProvider: 'NonLocal',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })

--- a/packages/networks/src/chains/bulletin.ts
+++ b/packages/networks/src/chains/bulletin.ts
@@ -48,7 +48,7 @@ export const bulletinPolkadot = defineChain({
     addressEncoding: 0,
     proxyBlockProvider: 'Local',
     schedulerBlockProvider: 'NonLocal',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })

--- a/packages/networks/src/chains/collectives.ts
+++ b/packages/networks/src/chains/collectives.ts
@@ -32,7 +32,7 @@ export const collectivesPolkadot = defineChain({
     addressEncoding: 0,
     proxyBlockProvider: 'Local',
     schedulerBlockProvider: 'Local',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })

--- a/packages/networks/src/chains/coretime.ts
+++ b/packages/networks/src/chains/coretime.ts
@@ -34,7 +34,7 @@ export const coretimePolkadot = defineChain({
     addressEncoding: 0,
     proxyBlockProvider: 'Local',
     schedulerBlockProvider: 'NonLocal',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })
@@ -50,7 +50,7 @@ export const coretimeKusama = defineChain({
     addressEncoding: 2,
     proxyBlockProvider: 'Local',
     schedulerBlockProvider: 'NonLocal',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })

--- a/packages/networks/src/chains/encointer.ts
+++ b/packages/networks/src/chains/encointer.ts
@@ -29,7 +29,7 @@ export const encointerKusama = defineChain({
   properties: {
     addressEncoding: 2,
     schedulerBlockProvider: 'Local',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })

--- a/packages/networks/src/chains/hydration.ts
+++ b/packages/networks/src/chains/hydration.ts
@@ -39,7 +39,7 @@ export const hydration = defineChain({
   properties: {
     addressEncoding: 0,
     schedulerBlockProvider: 'Local',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })
@@ -54,7 +54,7 @@ export const basilisk = defineChain({
   properties: {
     addressEncoding: 10041,
     schedulerBlockProvider: 'Local',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })

--- a/packages/networks/src/chains/moonbeam.ts
+++ b/packages/networks/src/chains/moonbeam.ts
@@ -56,7 +56,7 @@ export const moonbeam = defineChain({
   properties: {
     addressEncoding: 1284,
     schedulerBlockProvider: 'Local',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })
@@ -71,7 +71,7 @@ export const moonriver = defineChain({
   properties: {
     addressEncoding: 1285,
     schedulerBlockProvider: 'Local',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })

--- a/packages/networks/src/chains/people.ts
+++ b/packages/networks/src/chains/people.ts
@@ -52,7 +52,7 @@ export const peoplePolkadot = defineChain({
     addressEncoding: 0,
     proxyBlockProvider: 'NonLocal',
     schedulerBlockProvider: 'NonLocal',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })
@@ -68,7 +68,7 @@ export const peopleKusama = defineChain({
     addressEncoding: 2,
     proxyBlockProvider: 'Local',
     schedulerBlockProvider: 'NonLocal',
-    asyncBacking: 'Enabled',
+    relayBlocksPerParaBlock: 2,
     feeExtractor: standardFeeExtractor,
   },
 })

--- a/packages/networks/src/types.ts
+++ b/packages/networks/src/types.ts
@@ -39,7 +39,7 @@ interface ChainConfigRelaychain {
 interface ChainConfigParachain {
   isRelayChain?: false
   paraId: number
-  properties: ChainProperties & { asyncBacking: 'Enabled' | 'Disabled' }
+  properties: ChainProperties & { relayBlocksPerParaBlock: number }
 }
 
 type ChainConfigBase = {

--- a/packages/polkadot/src/acala.astar.xcm.test.ts
+++ b/packages/polkadot/src/acala.astar.xcm.test.ts
@@ -6,7 +6,7 @@ import { runXtokenstHorizontal } from '@e2e-test/shared/xcm'
 
 import { describe } from 'vitest'
 
-describe('acala & astar', { skip: true }, async () => {
+describe('acala & astar', async () => {
   const [astarClient, acalaClient, assetHubPolkadotClient] = await setupNetworks(astar, acala, assetHubPolkadot)
 
   runXtokenstHorizontal('astar transfer ACA to acala', async () => {

--- a/packages/polkadot/src/acala.astar.xcm.test.ts
+++ b/packages/polkadot/src/acala.astar.xcm.test.ts
@@ -6,7 +6,7 @@ import { runXtokenstHorizontal } from '@e2e-test/shared/xcm'
 
 import { describe } from 'vitest'
 
-describe('acala & astar', async () => {
+describe('acala & astar', { skip: true }, async () => {
   const [astarClient, acalaClient, assetHubPolkadotClient] = await setupNetworks(astar, acala, assetHubPolkadot)
 
   runXtokenstHorizontal('astar transfer ACA to acala', async () => {

--- a/packages/polkadot/src/acala.bifrostPolkadot.xcm.test.ts
+++ b/packages/polkadot/src/acala.bifrostPolkadot.xcm.test.ts
@@ -6,7 +6,7 @@ import { runXcmPalletHorizontal, runXtokenstHorizontal } from '@e2e-test/shared/
 
 import { describe } from 'vitest'
 
-describe('acala & bifrostPolkadot', { skip: true }, async () => {
+describe('acala & bifrostPolkadot', async () => {
   const [acalaClient, bifrostPolkadotClient, assetHubPolkadotClient] = await setupNetworks(
     acala,
     bifrostPolkadot,

--- a/packages/polkadot/src/acala.bifrostPolkadot.xcm.test.ts
+++ b/packages/polkadot/src/acala.bifrostPolkadot.xcm.test.ts
@@ -6,7 +6,7 @@ import { runXcmPalletHorizontal, runXtokenstHorizontal } from '@e2e-test/shared/
 
 import { describe } from 'vitest'
 
-describe('acala & bifrostPolkadot', async () => {
+describe('acala & bifrostPolkadot', { skip: true }, async () => {
   const [acalaClient, bifrostPolkadotClient, assetHubPolkadotClient] = await setupNetworks(
     acala,
     bifrostPolkadot,

--- a/packages/shared/src/accounts.ts
+++ b/packages/shared/src/accounts.ts
@@ -337,7 +337,7 @@ export const vestedTransferLockAction = <
   execute: async (client: Client<TCustom, TInitStorages>, alice: KeyringPair, amount: bigint): Promise<void> => {
     const offset = blockProviderOffset(
       client.config.properties.schedulerBlockProvider,
-      (client.config.properties as any).asyncBacking,
+      (client.config.properties as any).relayBlocksPerParaBlock,
     )
     const number = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
     const perBlock = client.api.consts.balances.existentialDeposit.toBigInt()

--- a/packages/shared/src/bounties.ts
+++ b/packages/shared/src/bounties.ts
@@ -113,7 +113,7 @@ async function setLastSpendPeriodBlockNumber(client: Client<any, any>) {
   const currentBlock = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
 
   const newLastSpendPeriodBlockNumber = match(client.config.properties.schedulerBlockProvider)

--- a/packages/shared/src/childBounties.ts
+++ b/packages/shared/src/childBounties.ts
@@ -158,7 +158,7 @@ async function setLastSpendPeriodBlockNumber(client: Client<any, any>) {
   const currentBlock = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
 
   const newLastSpendPeriodBlockNumber = match(client.config.properties.schedulerBlockProvider)

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -474,13 +474,14 @@ export async function referendumLifecycleTest<
   let refPre = ongoingRefPostDecDep
   let refPost: PalletReferendaReferendumStatusConvictionVotingTally
 
+  const relayBlocksPerParaBlock = (client.config.properties as any).relayBlocksPerParaBlock ?? 1
   let iters: number
   match(client.config.properties.schedulerBlockProvider)
     .with('Local', async () => {
       iters = smallTipper[1].preparePeriod.toNumber() - 2
     })
     .with('NonLocal', async () => {
-      iters = (smallTipper[1].preparePeriod.toNumber() - 2) / 2
+      iters = (smallTipper[1].preparePeriod.toNumber() - 2) / relayBlocksPerParaBlock
     })
     .exhaustive()
 
@@ -805,7 +806,7 @@ export async function referendumLifecycleTest<
       expect(cancelledRef[0].toNumber()).toBe(blockNumber)
     })
     .with('NonLocal', async () => {
-      expect(cancelledRef[0].toNumber()).toBe(blockNumber - 2)
+      expect(cancelledRef[0].toNumber()).toBe(blockNumber - relayBlocksPerParaBlock)
     })
   // Check that the referendum's submission deposit was refunded to Alice
   expect(cancelledRef[1].unwrap().toJSON()).toEqual({
@@ -1072,13 +1073,14 @@ export async function referendumLifecycleKillTest<
 
   // The only information left from the killed referendum is the block number when it was killed.
   const blockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
+  const relayBlocksPerParaBlock = (client.config.properties as any).relayBlocksPerParaBlock ?? 1
   const killedRef: u32 = referendumDataOpt.unwrap().asKilled
   match(client.config.properties.schedulerBlockProvider)
     .with('Local', async () => {
       expect(killedRef.toNumber()).toBe(blockNumber)
     })
     .with('NonLocal', async () => {
-      expect(killedRef.toNumber()).toBe(blockNumber - 2)
+      expect(killedRef.toNumber()).toBe(blockNumber - relayBlocksPerParaBlock)
     })
 }
 
@@ -2056,13 +2058,14 @@ export async function referendumLifecycleDelegationTest<
   await client.dev.newBlock()
 
   // Advance to the start of the decision period
+  const relayBlocksPerParaBlock = (client.config.properties as any).relayBlocksPerParaBlock ?? 1
   let iters: number
   match(client.config.properties.schedulerBlockProvider)
     .with('Local', async () => {
       iters = smallTipper[1].preparePeriod.toNumber() - 2
     })
     .with('NonLocal', async () => {
-      iters = (smallTipper[1].preparePeriod.toNumber() - 2) / 2
+      iters = (smallTipper[1].preparePeriod.toNumber() - 2) / relayBlocksPerParaBlock
     })
     .exhaustive()
 

--- a/packages/shared/src/helpers/index.ts
+++ b/packages/shared/src/helpers/index.ts
@@ -104,9 +104,6 @@ export function objectCmp(
  */
 export type BlockProvider = 'Local' | 'NonLocal'
 
-/** Whether async backing is enabled or disabled on the querying parachain. */
-export type AsyncBacking = 'Enabled' | 'Disabled'
-
 /**
  * Given a PJS client and a call, modify the `scheduler` pallet's `agenda` storage to execute the list of extrinsics
  * in the next block.
@@ -524,26 +521,20 @@ export async function nextSchedulableBlockNum(api: ApiPromise, blockProvider: Bl
  *
  * * If on a relay chain, the output is 1 i.e. when injecting a task into the scheduler pallet's agenda storage,
  *   every block number is available.
- * * If on a parachain without AB, 1, with the same meaning as above.
- * * If on a parachain with AB, the offset is 2, because `parachainSystem.lastRelayChainBlockNumber` moves with a step
- *   size of 2, and thus, manually scheduled blocks can only be injected every other relay block number. Also applies
- *   to vesting and treasury spend periods.
+ * * If on a parachain, `relayBlocksPerParaBlock` — the number of relay blocks that elapse per parachain block,
+ *   as configured via the chain's consensus parameters (e.g. `BLOCK_PROCESSING_VELOCITY`). Defaults to 1 if
+ *   not provided.
  *
  * @param blockProvider Whether the call is being scheduled on a relay or parachain.
- * @param asyncBacking Whether async backing is enabled on the parachain.
+ * @param relayBlocksPerParaBlock Relay blocks elapsed per parachain block; sourced from chain config.
  * @returns The number of blocks to offset when scheduling tasks
  */
-export function blockProviderOffset(blockProvider: BlockProvider, asyncBacking?: AsyncBacking): number {
+export function blockProviderOffset(blockProvider: BlockProvider, relayBlocksPerParaBlock?: number): number {
   if (blockProvider === 'Local') {
     return 1
   }
 
-  if (asyncBacking === 'Enabled') {
-    return 2
-  }
-
-  // On a parachain without async backing.
-  return 1
+  return relayBlocksPerParaBlock ?? 1
 }
 
 /**
@@ -584,7 +575,7 @@ export async function getReservedFunds(client: Client<any, any>, address: any): 
 
 /**
  * Configuration for tests.
- * Chain properties (addressEncoding, blockProvider, asyncBacking, etc.) are now
+ * Chain properties (addressEncoding, blockProvider, relayBlocksPerParaBlock, etc.) are now
  * provided by the chain definition and available via `chain.properties`.
  */
 export interface TestConfig {

--- a/packages/shared/src/multisig.proxy.ts
+++ b/packages/shared/src/multisig.proxy.ts
@@ -1030,7 +1030,7 @@ async function multisigAsStandardProxyAnnouncementWithDelayTest<
 
     const blockOffset = blockProviderOffset(
       client.config.properties.proxyBlockProvider!,
-      (client.config.properties as any).asyncBacking,
+      (client.config.properties as any).relayBlocksPerParaBlock,
     )
     proxyDelay -= blockOffset
 

--- a/packages/shared/src/proxy.ts
+++ b/packages/shared/src/proxy.ts
@@ -1928,7 +1928,7 @@ export async function proxyAnnouncementLifecycleTest<
 
   const offset = blockProviderOffset(
     client.config.properties.proxyBlockProvider!,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
 
   announcements = await client.api.query.proxy.announcements(bob.address)

--- a/packages/shared/src/scheduler.ts
+++ b/packages/shared/src/scheduler.ts
@@ -274,7 +274,7 @@ export async function cancelScheduledTaskBadOriginTest<
   const initialBlockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   let targetBlockNumber: number
   match(client.config.properties.schedulerBlockProvider)
@@ -334,7 +334,7 @@ export async function cancelNamedScheduledTaskBadOriginTest<
   const initialBlockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   let targetBlockNumber: number
   match(client.config.properties.schedulerBlockProvider)
@@ -400,7 +400,7 @@ export async function scheduledCallExecutes<
   const initialBlockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   let targetBlockNumber: number
   match(client.config.properties.schedulerBlockProvider)
@@ -478,7 +478,7 @@ export async function scheduledNamedCallExecutes<
   const initialBlockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   let targetBlockNumber: number
   match(client.config.properties.schedulerBlockProvider)
@@ -649,7 +649,7 @@ export async function cancelScheduledNamedTask<
   const initialBlockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   let targetBlockNumber: number
   match(client.config.properties.schedulerBlockProvider)
@@ -792,7 +792,7 @@ export async function cancelNamedTaskWithUnnamedCancellation<
   const initialBlockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   let targetBlockNumber: number
   match(client.config.properties.schedulerBlockProvider)
@@ -917,7 +917,7 @@ export async function cancelNamedTask<
   const initialBlockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   // This is *not* the same timespan across relay/parachains, but it's irrelevant: what's necessary is a task far in
   // the future.
@@ -1100,7 +1100,7 @@ export async function scheduleTaskAfterDelay<
 
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   // In case of non-local block providers, spans of blocks must be specified in terms of the nonlocal
   // provider.
@@ -1201,7 +1201,7 @@ export async function scheduleNamedTaskAfterDelay<
 
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   // See above note in `scheduleTaskAfterDelay`
   const delay = 5 * offset
@@ -1301,7 +1301,7 @@ export async function scheduledOverweightCallFails<
 
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   const initialBlockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   // Target block is two blocks in the future - see the notes about parachain scheduling differences.
@@ -1522,7 +1522,7 @@ export async function schedulePreimagedCall<
   const initialBlockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   // Target block number is two blocks in the future: if `n` is the most recent block, the task should be executed
   // at `n + 2`.
@@ -1686,7 +1686,7 @@ async function testPeriodicTask<
 ) {
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
 
   // Manually schedule `scheduleTx` to run on the next block.
@@ -1840,7 +1840,7 @@ export async function schedulePeriodicTask<
 
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   const delay = match(client.config.properties.schedulerBlockProvider)
     .with('Local', () => 2 * offset)
@@ -1878,7 +1878,7 @@ export async function scheduleNamedPeriodicTask<
 
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   const delay = match(client.config.properties.schedulerBlockProvider)
     .with('Local', () => 2 * offset)
@@ -1933,7 +1933,7 @@ export async function schedulePriorityWeightedTasks<
   let currBlockNumber = initBlockNumber
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   let priorityTargetBlock: number
   match(client.config.properties.schedulerBlockProvider)
@@ -2165,7 +2165,7 @@ export async function scheduleWithRetryConfig<
 
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
 
   const period = 3 * offset
@@ -2326,7 +2326,7 @@ export async function scheduleNamedWithRetryConfig<
 
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
 
   const period = 3 * offset
@@ -2534,7 +2534,7 @@ export async function scheduleToFullAgenda<
   const initialBlockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   const targetBlockNumber = initialBlockNumber + 1000 * offset
 
@@ -2614,7 +2614,7 @@ export async function retryReschedulingNamedTaskToFullAgenda<
   const initialBlockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
 
   // ---------------------------------------------------
@@ -2759,7 +2759,7 @@ export async function retryReschedulingAnonymousTaskToFullAgenda<
   const initialBlockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
 
   // ---------------------------------------------------

--- a/packages/shared/src/vesting.ts
+++ b/packages/shared/src/vesting.ts
@@ -46,7 +46,7 @@ async function testVestedTransfer<
   const currBlockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
 
   // On KAH, the minimum vested amount is not divisible by 8 (it isn't even even :) ), so this multiplication is needed.
@@ -273,7 +273,7 @@ async function testForceVestedTransferAndRemoval<
   const currBlockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
 
   const locked = client.api.consts.vesting.minVestedTransfer.toNumber()
@@ -384,7 +384,7 @@ async function testMergeVestingSchedules<
   let currBlockNumber = await getBlockNumber(client.api, client.config.properties.schedulerBlockProvider)
   const offset = blockProviderOffset(
     client.config.properties.schedulerBlockProvider,
-    (client.config.properties as any).asyncBacking,
+    (client.config.properties as any).relayBlocksPerParaBlock,
   )
   const initialBlockNumber = currBlockNumber
 

--- a/scripts/generate-ci-matrix.mjs
+++ b/scripts/generate-ci-matrix.mjs
@@ -36,6 +36,7 @@ const CHAIN_ORDER = {
 		'coretimePolkadot',
 		'peoplePolkadot',
 		'acala',
+		'astar',
 		'hydration',
 		'bifrostPolkadot',
 	],

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -27,6 +27,8 @@ export default defineConfig({
 			'**/.git/**',
 			'packages/kusama/src/bifrostKusama.*.test.ts',
 			'packages/kusama/src/karura.bifrostKusama.xcm.test.ts',
+			'packages/polkadot/src/acala.astar.xcm.test.ts',
+			'packages/polkadot/src/acala.bifrostPolkadot.xcm.test.ts',
 		],
 	},
 	build: {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -27,7 +27,6 @@ export default defineConfig({
 			'**/.git/**',
 			'packages/kusama/src/bifrostKusama.*.test.ts',
 			'packages/kusama/src/karura.bifrostKusama.xcm.test.ts',
-			'packages/polkadot/src/acala.astar.xcm.test.ts',
 			'packages/polkadot/src/acala.bifrostPolkadot.xcm.test.ts',
 		],
 	},


### PR DESCRIPTION
Closes #631.

The `asyncBacking: 'Enabled'` flag was used in `blockProviderOffset` to return a hardcoded offset of 2 relay blocks per parachain block. This assumption breaks as chains move to different block times via elastic scaling.

Replace the boolean `asyncBacking` chain property with a numeric `relayBlocksPerParaBlock`. All chains currently producing one parachain block per 2 relay blocks are set to 2. The value can be updated per chain when its block time changes — no code changes needed, only the chain config entry.

Validated against [polkadot-fellows/runtimes#1195](https://github.com/polkadot-fellows/runtimes/pull/1195): with the correct per-chain value set, the scheduler, vesting, governance, and proxy test failures caused by wrong block arithmetic are resolved.