### PR TITLE
Remove IBP endpoints due to program shutdown

### DIFF
--- a/packages/networks/src/pet-chain-endpoints.json
+++ b/packages/networks/src/pet-chain-endpoints.json
@@ -51,7 +51,9 @@
     "wss://hk.p.bifrost-rpc.liebi.com/ws"
   ],
   "hydration": [
-    "wss://rpc.hydradx.cloud"
+    "wss://hydration-rpc.n.dwellir.com",
+    "wss://rpc.hydradx.cloud",
+    "wss://rpc.helikon.io/hydradx"
   ],
   "moonbeam": [
     "wss://wss.api.moonbeam.network"

--- a/packages/networks/src/pet-chain-endpoints.json
+++ b/packages/networks/src/pet-chain-endpoints.json
@@ -1,9 +1,7 @@
 {
   "polkadot": [
     "wss://polkadot-rpc.n.dwellir.com",
-    "wss://rpc.ibp.network/polkadot",
     "wss://rpc-polkadot.luckyfriday.io",
-    "wss://polkadot.dotters.network",
     "wss://dot-rpc.stakeworld.io",
     "wss://rpc-polkadot.helixstreet.io",
     "wss://polkadot.api.onfinality.io/public-ws",
@@ -14,29 +12,21 @@
     "wss://westend-asset-hub-rpc.polkadot.io"
   ],
   "assetHubPolkadot": [
-    "wss://sys.ibp.network/asset-hub-polkadot",
-    "wss://asset-hub-polkadot.dotters.network",
     "wss://dot-rpc.stakeworld.io/assethub",
     "wss://rpc-asset-hub-polkadot.luckyfriday.io",
     "wss://asset-hub-polkadot-rpc.n.dwellir.com"
   ],
   "bridgeHubPolkadot": [
-    "wss://sys.ibp.network/bridgehub-polkadot",
-    "wss://bridge-hub-polkadot.dotters.network",
     "wss://rpc-bridge-hub-polkadot.luckyfriday.io",
     "wss://bridge-hub-polkadot-rpc.n.dwellir.com",
     "wss://dot-rpc.stakeworld.io/bridgehub"
   ],
   "collectivesPolkadot": [
-    "wss://sys.ibp.network/collectives-polkadot",
-    "wss://collectives-polkadot.dotters.network",
     "wss://rpc-collectives-polkadot.luckyfriday.io",
     "wss://collectives-polkadot-rpc.n.dwellir.com",
     "wss://dot-rpc.stakeworld.io/collectives"
   ],
   "coretimePolkadot": [
-    "wss://sys.ibp.network/coretime-polkadot",
-    "wss://coretime-polkadot.dotters.network",
     "wss://coretime-polkadot.api.onfinality.io/public-ws",
     "wss://rpc-coretime-polkadot.luckyfriday.io",
     "wss://coretime-polkadot-rpc.n.dwellir.com",
@@ -46,8 +36,6 @@
     "wss://bulletin-rpc.polkadot.io"
   ],
   "peoplePolkadot": [
-    "wss://sys.ibp.network/people-polkadot",
-    "wss://people-polkadot.dotters.network",
     "wss://people-polkadot.api.onfinality.io/public-ws",
     "wss://rpc-people-polkadot.luckyfriday.io",
     "wss://people-polkadot-rpc.n.dwellir.com",
@@ -63,8 +51,6 @@
     "wss://hk.p.bifrost-rpc.liebi.com/ws"
   ],
   "hydration": [
-    "wss://hydration.ibp.network",
-    "wss://hydration.dotters.network",
     "wss://rpc.hydradx.cloud"
   ],
   "moonbeam": [
@@ -75,36 +61,26 @@
   ],
   "kusama": [
     "wss://kusama-rpc.n.dwellir.com",
-    "wss://rpc.ibp.network/kusama",
-    "wss://kusama.dotters.network",
     "wss://rpc-kusama.luckyfriday.io",
     "wss://kusama.api.onfinality.io/public-ws"
   ],
   "assetHubKusama": [
-    "wss://sys.ibp.network/asset-hub-kusama",
-    "wss://asset-hub-kusama.dotters.network",
     "wss://rpc-asset-hub-kusama.luckyfriday.io",
     "wss://asset-hub-kusama-rpc.n.dwellir.com",
     "wss://ksm-rpc.stakeworld.io/assethub"
   ],
   "bridgeHubKusama": [
-    "wss://sys.ibp.network/bridgehub-kusama",
-    "wss://bridge-hub-kusama.dotters.network",
     "wss://rpc-bridge-hub-kusama.luckyfriday.io",
     "wss://bridge-hub-kusama-rpc.n.dwellir.com",
     "wss://ksm-rpc.stakeworld.io/bridgehub"
   ],
   "coretimeKusama": [
-    "wss://sys.ibp.network/coretime-kusama",
-    "wss://coretime-kusama.dotters.network",
     "wss://rpc-coretime-kusama.luckyfriday.io",
     "wss://coretime-kusama-rpc.n.dwellir.com",
     "wss://ksm-rpc.stakeworld.io/coretime",
     "wss://coretime-kusama.api.onfinality.io/public-ws"
   ],
   "peopleKusama": [
-    "wss://sys.ibp.network/people-kusama",
-    "wss://people-kusama.dotters.network",
     "wss://rpc-people-kusama.luckyfriday.io",
     "wss://people-kusama-rpc.n.dwellir.com",
     "wss://ksm-rpc.stakeworld.io/people",
@@ -112,8 +88,6 @@
     "wss://people-kusama.api.onfinality.io/public-ws"
   ],
   "encointerKusama": [
-    "wss://sys.ibp.network/encointer-kusama",
-    "wss://encointer-kusama.dotters.network",
     "wss://rpc-encointer-kusama.luckyfriday.io",
     "wss://encointer-kusama-rpc.n.dwellir.com"
   ],


### PR DESCRIPTION
## Summary

- Remove all 26 IBP endpoint entries (`*.ibp.network` and `*.dotters.network`) from `pet-chain-endpoints.json`
- The Infrastructure Builders Programme (IBP) is shutting down operations as signaled in [referendum 1891](https://polkadot.subsquare.io/referenda/1891)

Mirrors the endpoint removals in:
- paritytech/polkadot-sdk#12284 (bootnodes)
- polkadot-js/apps#12311 (RPC endpoints)

Affected chains: polkadot, assetHubPolkadot, bridgeHubPolkadot, collectivesPolkadot, coretimePolkadot, peoplePolkadot, hydration, kusama, assetHubKusama, bridgeHubKusama, coretimeKusama, peopleKusama, encointerKusama.

All chains retain at least one other endpoint (Dwellir, LuckyFriday, Stakeworld, OnFinality, etc.).