### PR TITLE
Remove dead and non-archive RPC endpoints

### DIFF
--- a/packages/networks/src/pet-chain-endpoints.json
+++ b/packages/networks/src/pet-chain-endpoints.json
@@ -4,8 +4,7 @@
     "wss://rpc-polkadot.luckyfriday.io",
     "wss://dot-rpc.stakeworld.io",
     "wss://rpc-polkadot.helixstreet.io",
-    "wss://polkadot.api.onfinality.io/public-ws",
-    "wss://polkadot-rpc.publicnode.com"
+    "wss://polkadot.api.onfinality.io/public-ws"
   ],
   "assetHubWestend": [
     "wss://asset-hub-westend-rpc.n.dwellir.com",
@@ -52,8 +51,7 @@
   ],
   "hydration": [
     "wss://hydration-rpc.n.dwellir.com",
-    "wss://rpc.hydradx.cloud",
-    "wss://rpc.helikon.io/hydradx"
+    "wss://rpc.hydradx.cloud"
   ],
   "moonbeam": [
     "wss://wss.api.moonbeam.network"


### PR DESCRIPTION
## Summary

Follow-up to #634. Remove 2 endpoints from `pet-chain-endpoints.json` that are dead or non-archive, identified from the [Probe RPC Endpoints](https://github.com/open-web3-stack/polkadot-ecosystem-tests/actions/runs/27335572948) workflow and [failing CI run](https://github.com/open-web3-stack/polkadot-ecosystem-tests/actions/runs/27358526571/job/80839423949):

| Endpoint | Chain | Issue | Evidence |
|---|---|---|---|
| `wss://polkadot-rpc.publicnode.com` | polkadot | **Non-archive** — cannot serve historical state | Probe: `archive: false`, `UnknownBlock: State already discarded`; likely root cause of Polkadot relay proxy test timeouts (`No response received from RPC endpoint in 90s`) |
| `wss://rpc.helikon.io/hydradx` | hydration | **Dead** — HTTP 400 on connect | Probe: `connect: Unexpected server response: 400`; failing on every CI run since introduced in #634 |

### Remaining chains after removal
- **polkadot**: 5 endpoints (Dwellir, LuckyFriday, Stakeworld, HelixStreet, OnFinality) — all archive ✅
- **hydration**: 2 endpoints (Dwellir, HydraDX) — both archive ✅

### Known issue not addressed
- **bifrostKusama**: both endpoints (`hk.bifrost-rpc.liebi.com`, `bifrost-rpc.liebi.com`) are **non-archive** per the probe, but no public archive alternative is known — left as-is to avoid breaking Kusama tests