### PR TITLE
Add Fellowship whitelist-over-bridge e2e test; bump chopsticks to 1.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ These include:
   - ceiling dynamics: per-asset and global debt ceilings, weight normalisation, interactions
     between assets at their respective ceilings
   - reserve integrity: minting within/exceeding global ceiling, debt accumulation, over-redemption
+- E2E test for cross-consensus bridge scenarios:
+  - Fellowship whitelists a call on Kusama Asset Hub over the Polkadot-Kusama bridge
+    (Collectives -> Asset Hub Polkadot -> Bridge Hub Polkadot -> Bridge Hub Kusama -> Asset Hub Kusama)
+  - Uses chopsticks' `connectBridgeHubs` to relay bridge messages between forked chains
 - E2E test suite for the `configuration` pallet on relay chains:
   - Scheduling configuration updates via Root origin across all parameter groups: core (code size, PoV size, upgrade cooldown/delay), scheduler (group rotation, availability period, lookahead, validators per core), dispute resolution, message queue (upward/downward queue limits), HRMP channel parameters, and advanced parameters (PVF voting TTL, async backing params, executor params, approval voting, node features)
   - Verifying that the pending config entry is scheduled for session index `currentIndex + 2`

--- a/packages/polkadot/src/__snapshots__/collectivesPolkadot.assetHubKusama.whitelist.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/collectivesPolkadot.assetHubKusama.whitelist.e2e.test.ts.snap
@@ -1,0 +1,108 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Polkadot Fellowship whitelists a call on Kusama Asset Hub over the bridge > fellowship whitelistCall reaches Kusama Asset Hub via the P↔K bridge > collectives sends fellowship whitelist xcm toward kusama 1`] = `
+[
+  {
+    "data": {
+      "destination": {
+        "interior": {
+          "X1": [
+            {
+              "Parachain": 1000,
+            },
+          ],
+        },
+        "parents": 1,
+      },
+      "message": [
+        {
+          "UnpaidExecution": {
+            "checkOrigin": null,
+            "weightLimit": "Unlimited",
+          },
+        },
+        {
+          "InitiateTransfer": {
+            "assets": [],
+            "destination": {
+              "interior": {
+                "X2": [
+                  {
+                    "GlobalConsensus": "Kusama",
+                  },
+                  {
+                    "Parachain": 1000,
+                  },
+                ],
+              },
+              "parents": 2,
+            },
+            "preserveOrigin": true,
+            "remoteFees": null,
+            "remoteXcm": [
+              {
+                "Transact": {
+                  "call": {
+                    "encoded": "0x5e000101010101010101010101010101010101010101010101010101010101010101",
+                  },
+                  "fallbackMaxWeight": null,
+                  "originKind": "Xcm",
+                },
+              },
+              {
+                "ExpectTransactStatus": "Success",
+              },
+            ],
+          },
+        },
+      ],
+      "messageId": "(redacted)",
+      "origin": {
+        "interior": {
+          "X2": [
+            {
+              "Plurality": {
+                "id": "Technical",
+                "part": "Voice",
+              },
+            },
+            {
+              "GeneralIndex": 3,
+            },
+          ],
+        },
+        "parents": 0,
+      },
+    },
+    "method": "Sent",
+    "section": "polkadotXcm",
+  },
+]
+`;
+
+exports[`Polkadot Fellowship whitelists a call on Kusama Asset Hub over the bridge > fellowship whitelistCall reaches Kusama Asset Hub via the P↔K bridge > kusama asset hub whitelists the call via the bridged fellowship origin 1`] = `
+[
+  {
+    "data": {
+      "callHash": "0x0101010101010101010101010101010101010101010101010101010101010101",
+    },
+    "method": "CallWhitelisted",
+    "section": "whitelist",
+  },
+  {
+    "data": {
+      "id": "(redacted)",
+      "origin": {
+        "Sibling": "(rounded 1000)",
+      },
+      "success": true,
+      "weightUsed": {
+        "proofSize": "(rounded 5000)",
+        "refTime": "(rounded 200000000)",
+      },
+    },
+    "method": "Processed",
+    "section": "messageQueue",
+  },
+]
+`;

--- a/packages/polkadot/src/collectivesPolkadot.assetHubKusama.whitelist.e2e.test.ts
+++ b/packages/polkadot/src/collectivesPolkadot.assetHubKusama.whitelist.e2e.test.ts
@@ -1,0 +1,23 @@
+import {
+  assetHubKusama,
+  assetHubPolkadot,
+  bridgeHubKusama,
+  bridgeHubPolkadot,
+  collectivesPolkadot,
+} from '@e2e-test/networks/chains'
+import { fellowshipWhitelistsCallOverBridge, registerTestTree, type TestConfig } from '@e2e-test/shared'
+
+const testConfig: TestConfig = {
+  testSuiteName: 'Polkadot Fellowship whitelists a call on Kusama Asset Hub over the bridge',
+}
+
+registerTestTree(
+  fellowshipWhitelistsCallOverBridge(
+    collectivesPolkadot,
+    assetHubPolkadot,
+    bridgeHubPolkadot,
+    bridgeHubKusama,
+    assetHubKusama,
+    testConfig,
+  ),
+)

--- a/packages/shared/src/bridge.ts
+++ b/packages/shared/src/bridge.ts
@@ -19,13 +19,16 @@ type BridgeHandle = Awaited<ReturnType<typeof connectBridgeHubs>>
 
 const delay = (ms: number) => new Promise((r) => setTimeout(r, ms))
 
-// Wait until `api`'s tx pool holds a transaction (bounded by `timeoutMs`). `connectBridgeHubs` submits
-// the bridge delivery into the pool out of band, so polling lets the test build the applying block as
-// soon as it lands.
-const waitForPoolTx = async (api: ApiPromise, timeoutMs = 20_000) => {
+// connectBridgeHubs submits the bridge delivery tx out of band, so we poll until it lands in the
+// pool before building the block that applies it. Throws on timeout so failures point here
+// instead of producing a confusing snapshot mismatch downstream.
+const waitForPoolTx = async (api: ApiPromise, timeoutMs = 30_000) => {
   const deadline = Date.now() + timeoutMs
   while (Date.now() < deadline && (await api.rpc.author.pendingExtrinsics()).length === 0) {
     await delay(200)
+  }
+  if ((await api.rpc.author.pendingExtrinsics()).length === 0) {
+    throw new Error(`No transaction appeared in the pool within ${timeoutMs}ms`)
   }
 }
 

--- a/packages/shared/src/bridge.ts
+++ b/packages/shared/src/bridge.ts
@@ -1,0 +1,178 @@
+import { connectBridgeHubs } from '@acala-network/chopsticks'
+
+import { type Chain, type Client, createNetworks } from '@e2e-test/networks'
+
+import type { ApiPromise } from '@polkadot/api'
+import { Keyring } from '@polkadot/keyring'
+import type { HexString } from '@polkadot/util/types'
+
+import {
+  assertExpectedEvents,
+  checkSystemEvents,
+  scheduleInlineCallWithOrigin,
+  type TestConfig,
+} from './helpers/index.js'
+import { setupBalances } from './setup.js'
+import type { RootTestTree } from './types.js'
+
+type BridgeHandle = Awaited<ReturnType<typeof connectBridgeHubs>>
+
+const delay = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+// Wait until `api`'s tx pool holds a transaction (bounded by `timeoutMs`). `connectBridgeHubs` submits
+// the bridge delivery into the pool out of band, so polling lets the test build the applying block as
+// soon as it lands.
+const waitForPoolTx = async (api: ApiPromise, timeoutMs = 20_000) => {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline && (await api.rpc.author.pendingExtrinsics()).length === 0) {
+    await delay(200)
+  }
+}
+
+/**
+ * The Polkadot Technical Fellowship (on Collectives) whitelists a call on Kusama Asset Hub over the
+ * P↔K bridge. Kusama Asset Hub maps the bridged Fellowship location
+ * `[GlobalConsensus(Polkadot), Parachain(1001), Plurality{Technical,Voice}, GeneralIndex(rank)]` to its
+ * whitelist origin.
+ *
+ *   Collectives --HRMP--> Asset Hub Polkadot --bridge--> Bridge Hub Kusama --HRMP--> Asset Hub Kusama
+ *
+ * Collectives has no bridge router, so it routes through sibling Asset Hub Polkadot, which forwards over
+ * the bridge with `InitiateTransfer { preserveOrigin: true }` to re-anchor the Fellowship origin onto
+ * Kusama Asset Hub. The bridge hop is relayed by chopsticks' `connectBridgeHubs`.
+ */
+export function fellowshipWhitelistsCallOverBridge(
+  collectivesChain: Chain,
+  assetHubPolkadotChain: Chain,
+  bridgeHubPolkadotChain: Chain,
+  bridgeHubKusamaChain: Chain,
+  assetHubKusamaChain: Chain,
+  testConfig: TestConfig,
+): RootTestTree {
+  let collectives!: Client
+  let ahPolkadot!: Client
+  let bhPolkadot!: Client
+  let bhKusama!: Client
+  let ahKusama!: Client
+  let forward!: BridgeHandle
+  let reverse!: BridgeHandle
+
+  return {
+    kind: 'describe',
+    label: testConfig.testSuiteName,
+    beforeAll: async () => {
+      // Separate Polkadot and Kusama groups: both Asset Hubs are para 1000 and both Bridge Hubs are
+      // 1002, so a single group would collide in chopsticks' paraId-keyed HRMP routing.
+      ;[collectives, ahPolkadot, bhPolkadot] = await createNetworks(
+        collectivesChain,
+        assetHubPolkadotChain,
+        bridgeHubPolkadotChain,
+      )
+      ;[bhKusama, ahKusama] = await createNetworks(bridgeHubKusamaChain, assetHubKusamaChain)
+
+      // `InitiateTransfer` and the bridge transport are XCM v5; pin every hop so version negotiation
+      // can't downgrade them (the runtime's `force_xcm_version`).
+      for (const c of [ahPolkadot, bhPolkadot, bhKusama, ahKusama]) {
+        await c.dev.setStorage({ polkadotXcm: { safeXcmVersion: 5 } })
+      }
+
+      // One relayer per direction: both connectors submit to the same hubs, so a shared signer would
+      // collide on its nonce and drop a tx. Funded on both hubs (the forks don't fund them).
+      const keyring = new Keyring({ type: 'sr25519' })
+      const relayerForward = keyring.addFromUri('//Alice')
+      const relayerReverse = keyring.addFromUri('//Alice//reverse')
+      const relayers = [
+        { address: relayerForward.address, amount: 1_000_000_000_000_000n },
+        { address: relayerReverse.address, amount: 1_000_000_000_000_000n },
+      ]
+      for (const hub of [bhPolkadot, bhKusama]) {
+        await setupBalances(hub, relayers)
+      }
+
+      // Relay the bridge both ways (forward delivers Polkadot→Kusama; reverse carries confirmations back).
+      forward = await connectBridgeHubs(bhPolkadot.api, bhKusama.api, { signer: relayerForward })
+      reverse = await connectBridgeHubs(bhKusama.api, bhPolkadot.api, { signer: relayerReverse })
+    },
+    afterAll: async () => {
+      await forward.disconnect().catch(() => {})
+      await reverse.disconnect().catch(() => {})
+      for (const c of [collectives, ahPolkadot, bhPolkadot, bhKusama, ahKusama]) {
+        await c.api.disconnect().catch(() => {})
+        await c.teardown().catch(() => {})
+      }
+    },
+    children: [
+      {
+        kind: 'test',
+        label: 'fellowship whitelistCall reaches Kusama Asset Hub via the P↔K bridge',
+        flags: { timeout: 600_000 },
+        testFn: async () => {
+          // Dummy call hash to whitelist on Kusama Asset Hub.
+          const callHash: HexString = '0x0101010101010101010101010101010101010101010101010101010101010101'
+          const whitelistCall = ahKusama.api.tx.whitelist.whitelistCall(callHash).method.toHex() as HexString
+
+          // Kusama Asset Hub from a Polkadot parachain (parents 2, into the Kusama consensus); Asset Hub
+          // Polkadot from Collectives (a sibling).
+          const kusamaAssetHub = {
+            parents: 2,
+            interior: { X2: [{ GlobalConsensus: { Kusama: null } }, { Parachain: 1000 }] },
+          }
+          const assetHubPolkadotDest = { parents: 1, interior: { X1: [{ Parachain: 1000 }] } }
+
+          // Executed on Kusama Asset Hub under the re-anchored Fellowship origin.
+          const xcmOnKusamaAssetHub = [
+            { Transact: { originKind: 'Xcm', call: { encoded: whitelistCall }, fallbackMaxWeight: null } },
+            { ExpectTransactStatus: 'Success' },
+          ]
+
+          // Executed on Asset Hub Polkadot: forward over the bridge, preserving the Fellowship origin.
+          const xcmForAssetHubPolkadot = {
+            V5: [
+              { UnpaidExecution: { weightLimit: 'Unlimited', checkOrigin: null } },
+              {
+                InitiateTransfer: {
+                  destination: kusamaAssetHub,
+                  remoteFees: null,
+                  preserveOrigin: true,
+                  assets: [],
+                  remoteXcm: xcmOnKusamaAssetHub,
+                },
+              },
+            ],
+          }
+
+          // Collectives sends it to sibling Asset Hub Polkadot under the Fellowship origin.
+          const send = collectives.api.tx.polkadotXcm
+            .send({ V5: assetHubPolkadotDest }, xcmForAssetHubPolkadot)
+            .method.toHex() as HexString
+          await scheduleInlineCallWithOrigin(collectives, send, { FellowshipOrigins: 'Fellows' })
+
+          // HRMP between forked chains is delivered synchronously inside `dev.newBlock`, so the HRMP
+          // hops need no waiting; only the bridge hop is async.
+          await collectives.dev.newBlock()
+          await checkSystemEvents(collectives, 'polkadotXcm')
+            .redact({ hash: false, redactKeys: /messageId/ })
+            .toMatchSnapshot('collectives sends fellowship whitelist xcm toward kusama')
+
+          // Asset Hub Polkadot forwards over the bridge (export to Bridge Hub Polkadot's outbound lane).
+          await ahPolkadot.dev.newBlock()
+          await bhPolkadot.dev.newBlock()
+
+          // The connector reacts to Bridge Hub Polkadot's head out of band and submits the delivery into
+          // Bridge Hub Kusama's pool; wait for it, then build the block that applies it.
+          await waitForPoolTx(bhKusama.api)
+          await bhKusama.dev.newBlock() // apply the delivery → HRMP to Kusama Asset Hub
+          await ahKusama.dev.newBlock() // Kusama Asset Hub executes whitelist.whitelistCall
+
+          await checkSystemEvents(ahKusama, 'whitelist', 'messageQueue')
+            .redact({ hash: false, redactKeys: /id/ })
+            .toMatchSnapshot('kusama asset hub whitelists the call via the bridged fellowship origin')
+
+          assertExpectedEvents(await ahKusama.api.query.system.events(), [
+            { type: ahKusama.api.events.whitelist.CallWhitelisted, args: { callHash } },
+          ])
+        },
+      },
+    ],
+  }
+}

--- a/packages/shared/src/bridge.ts
+++ b/packages/shared/src/bridge.ts
@@ -34,15 +34,18 @@ const waitForPoolTx = async (api: ApiPromise, timeoutMs = 30_000) => {
 
 /**
  * The Polkadot Technical Fellowship (on Collectives) whitelists a call on Kusama Asset Hub over the
- * P↔K bridge. Kusama Asset Hub maps the bridged Fellowship location
- * `[GlobalConsensus(Polkadot), Parachain(1001), Plurality{Technical,Voice}, GeneralIndex(rank)]` to its
- * whitelist origin.
+ * P↔K bridge. Collectives has no bridge router, so it routes through sibling Asset Hub Polkadot,
+ * which forwards over the bridge with `InitiateTransfer { preserveOrigin: true }` to re-anchor the
+ * Fellowship origin onto Kusama Asset Hub.
  *
  *   Collectives --HRMP--> Asset Hub Polkadot --bridge--> Bridge Hub Kusama --HRMP--> Asset Hub Kusama
  *
- * Collectives has no bridge router, so it routes through sibling Asset Hub Polkadot, which forwards over
- * the bridge with `InitiateTransfer { preserveOrigin: true }` to re-anchor the Fellowship origin onto
- * Kusama Asset Hub. The bridge hop is relayed by chopsticks' `connectBridgeHubs`.
+ * 1. Collectives sends `polkadotXcm.send` under Fellowship origin toward sibling Asset Hub Polkadot
+ * 2. Asset Hub Polkadot forwards via `InitiateTransfer` over the bridge to Kusama Asset Hub
+ * 3. Bridge Hub Polkadot exports the message; `connectBridgeHubs` relays it to Bridge Hub Kusama
+ * 4. Bridge Hub Kusama delivers via HRMP to Asset Hub Kusama
+ * 5. Asset Hub Kusama executes `whitelist.whitelistCall` under the bridged Fellowship origin
+ * 6. Assert `whitelist.CallWhitelisted` on Asset Hub Kusama
  */
 export function fellowshipWhitelistsCallOverBridge(
   collectivesChain: Chain,
@@ -144,29 +147,28 @@ export function fellowshipWhitelistsCallOverBridge(
             ],
           }
 
-          // Collectives sends it to sibling Asset Hub Polkadot under the Fellowship origin.
+          // 1. Collectives sends polkadotXcm.send under Fellowship origin toward Asset Hub Polkadot
           const send = collectives.api.tx.polkadotXcm
             .send({ V5: assetHubPolkadotDest }, xcmForAssetHubPolkadot)
             .method.toHex() as HexString
           await scheduleInlineCallWithOrigin(collectives, send, { FellowshipOrigins: 'Fellows' })
-
-          // HRMP between forked chains is delivered synchronously inside `dev.newBlock`, so the HRMP
-          // hops need no waiting; only the bridge hop is async.
           await collectives.dev.newBlock()
           await checkSystemEvents(collectives, 'polkadotXcm')
             .redact({ hash: false, redactKeys: /messageId/ })
             .toMatchSnapshot('collectives sends fellowship whitelist xcm toward kusama')
 
-          // Asset Hub Polkadot forwards over the bridge (export to Bridge Hub Polkadot's outbound lane).
+          // 2-3. Asset Hub Polkadot forwards via InitiateTransfer; Bridge Hub Polkadot exports
           await ahPolkadot.dev.newBlock()
           await bhPolkadot.dev.newBlock()
 
-          // The connector reacts to Bridge Hub Polkadot's head out of band and submits the delivery into
-          // Bridge Hub Kusama's pool; wait for it, then build the block that applies it.
+          // 4. Bridge Hub Kusama receives the delivery (connectBridgeHubs relays it async)
           await waitForPoolTx(bhKusama.api)
-          await bhKusama.dev.newBlock() // apply the delivery → HRMP to Kusama Asset Hub
-          await ahKusama.dev.newBlock() // Kusama Asset Hub executes whitelist.whitelistCall
+          await bhKusama.dev.newBlock()
 
+          // 5. Asset Hub Kusama executes whitelist.whitelistCall under the bridged Fellowship origin
+          await ahKusama.dev.newBlock()
+
+          // 6. Assert CallWhitelisted on Asset Hub Kusama
           await checkSystemEvents(ahKusama, 'whitelist', 'messageQueue')
             .redact({ hash: false, redactKeys: /id/ })
             .toMatchSnapshot('kusama asset hub whitelists the call via the bridged fellowship origin')

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,6 +1,7 @@
 export * from './accounts.js'
 export * from './assetRate.js'
 export * from './bounties.js'
+export * from './bridge.js'
 export * from './childBounties.js'
 export * from './collectives.js'
 export * from './configuration.js'


### PR DESCRIPTION
Cross-consensus (Polkadot ↔ Kusama) test scenario: the Polkadot Fellowship whitelists a call on
Kusama Asset Hub over the bridge, asserting `whitelist.CallWhitelisted` on Kusama Asset Hub. Bumps
`@acala-network/chopsticks*` `^1.4.2` → `^1.5.0` for the `connectBridgeHubs` connector.

```
Collectives --HRMP--> Asset Hub Polkadot --bridge--> Bridge Hub Kusama --HRMP--> Asset Hub Kusama
```

Collectives has no bridge router, so it routes through Asset Hub Polkadot, which forwards over the bridge
with `InitiateTransfer { preserveOrigin: true }` to re-anchor the Fellowship origin onto Kusama Asset Hub.
