### PR TITLE
Disable acala.astar XCM test (RPC endpoint timeouts)

### DIFF
--- a/packages/polkadot/src/acala.astar.xcm.test.ts
+++ b/packages/polkadot/src/acala.astar.xcm.test.ts
@@ -6,7 +6,8 @@ import { runXtokenstHorizontal } from '@e2e-test/shared/xcm'
 
 import { describe } from 'vitest'
 
-describe('acala & astar', async () => {
+// Disabled: RPC endpoint timeouts causing known-good update failures (2026-07-12, 2026-07-13)
+describe.skip('acala & astar', async () => {
   const [astarClient, acalaClient, assetHubPolkadotClient] = await setupNetworks(astar, acala, assetHubPolkadot)
 
   runXtokenstHorizontal('astar transfer ACA to acala', async () => {


### PR DESCRIPTION
Both Acala and Astar RPC endpoints time out during network setup (no response in 90s), failing `polkadot shard 2/3` in the last 4+ known-good update runs. Skipping until endpoints stabilize.