### PR TITLE
Fix Acala endpoints: add numbered Acala Foundation RPCs, remove dead Dwellir and OnFinality

### DIFF
--- a/packages/networks/src/pet-chain-endpoints.json
+++ b/packages/networks/src/pet-chain-endpoints.json
@@ -1,8 +1,8 @@
 {
   "polkadot": [
     "wss://dot-rpc.stakeworld.io",
-    "wss://polkadot-rpc.n.dwellir.com",
     "wss://rpc-polkadot.helixstreet.io",
+    "wss://polkadot-rpc.n.dwellir.com",
     "wss://rpc-polkadot.luckyfriday.io",
     "wss://polkadot.api.onfinality.io/public-ws"
   ],
@@ -52,8 +52,8 @@
     "wss://hk.p.bifrost-rpc.liebi.com/ws"
   ],
   "hydration": [
-    "wss://hydration-rpc.n.dwellir.com",
-    "wss://rpc.hydradx.cloud"
+    "wss://rpc.hydradx.cloud",
+    "wss://hydration-rpc.n.dwellir.com"
   ],
   "moonbeam": [
     "wss://wss.api.moonbeam.network"
@@ -62,8 +62,8 @@
     "wss://astar-rpc.n.dwellir.com"
   ],
   "kusama": [
-    "wss://kusama-rpc.n.dwellir.com",
     "wss://rpc-kusama.luckyfriday.io",
+    "wss://kusama-rpc.n.dwellir.com",
     "wss://kusama.api.onfinality.io/public-ws"
   ],
   "assetHubKusama": [

--- a/packages/networks/src/pet-chain-endpoints.json
+++ b/packages/networks/src/pet-chain-endpoints.json
@@ -41,10 +41,11 @@
     "wss://people-polkadot.api.onfinality.io/public-ws"
   ],
   "acala": [
+    "wss://acala-rpc-0.aca-api.network",
+    "wss://acala-rpc-1.aca-api.network",
+    "wss://acala-rpc-3.aca-api.network/ws",
     "wss://acala-rpc.aca-api.network",
-    "wss://rpc-acala.luckyfriday.io",
-    "wss://acala-rpc.n.dwellir.com",
-    "wss://acala-polkadot.api.onfinality.io/public-ws"
+    "wss://rpc-acala.luckyfriday.io"
   ],
   "bifrostPolkadot": [
     "wss://eu.bifrost-polkadot-rpc.liebi.com/ws",

--- a/packages/networks/src/pet-chain-endpoints.json
+++ b/packages/networks/src/pet-chain-endpoints.json
@@ -44,8 +44,7 @@
     "wss://acala-rpc-0.aca-api.network",
     "wss://acala-rpc-1.aca-api.network",
     "wss://acala-rpc-3.aca-api.network/ws",
-    "wss://acala-rpc.aca-api.network",
-    "wss://rpc-acala.luckyfriday.io"
+    "wss://acala-rpc.aca-api.network"
   ],
   "bifrostPolkadot": [
     "wss://eu.bifrost-polkadot-rpc.liebi.com/ws",


### PR DESCRIPTION
Dwellir returns 503, OnFinality DNS is dead. Adds the 3 numbered Acala Foundation endpoints from PJS apps (acala-rpc-0, acala-rpc-1, acala-rpc-3) which all respond. Keeps the unnumbered acala-rpc and LuckyFriday.