### PR TITLE
Elide per-block-iterated storage maps on Acala, Karura and Hydration to cut fork RPC traffic

### DIFF
--- a/packages/networks/src/chains/acala.ts
+++ b/packages/networks/src/chains/acala.ts
@@ -79,6 +79,15 @@ const getInitStorages = (config: typeof custom.acala | typeof custom.karura) => 
     // avoid sending xcm version change notifications to makes things faster
     $removePrefix: ['versionNotifyTargets', 'versionNotifiers'],
   },
+  // Incentives.on_initialize iterates the reward pools each block, walking Rewards.PoolInfos and
+  // Incentives.IncentiveRewardAmounts from the upstream RPC. Neither is needed by the XCM transfer
+  // tests, so elide them to cut per-block remote getKeysPaged traffic during fork bootstrap.
+  Rewards: {
+    $removePrefix: ['poolInfos'],
+  },
+  Incentives: {
+    $removePrefix: ['incentiveRewardAmounts'],
+  },
 })
 
 export const acala = defineChain({

--- a/packages/networks/src/chains/acala.ts
+++ b/packages/networks/src/chains/acala.ts
@@ -79,14 +79,27 @@ const getInitStorages = (config: typeof custom.acala | typeof custom.karura) => 
     // avoid sending xcm version change notifications to makes things faster
     $removePrefix: ['versionNotifyTargets', 'versionNotifiers'],
   },
-  // Incentives.on_initialize iterates the reward pools each block, walking Rewards.PoolInfos and
-  // Incentives.IncentiveRewardAmounts from the upstream RPC. Neither is needed by the XCM transfer
-  // tests, so elide them to cut per-block remote getKeysPaged traffic during fork bootstrap.
+  // The Acala/Karura block hooks iterate several large maps every block, each iteration step
+  // becoming a remote getKeysPaged against the fork's upstream RPC. None of these are needed by
+  // the tests, so elide them to cut the per-block traffic that makes bootstrap flaky:
+  //   - Incentives.on_initialize      -> Rewards.PoolInfos, Incentives.IncentiveRewardAmounts
+  //   - DexOracle.on_initialize       -> DexOracle.AveragePrices
+  //   - IdleScheduler.on_idle         -> IdleScheduler.Tasks
+  //   - AuctionManager (Auction map)  -> Auction.AuctionEndTime
   Rewards: {
     $removePrefix: ['poolInfos'],
   },
   Incentives: {
     $removePrefix: ['incentiveRewardAmounts'],
+  },
+  DexOracle: {
+    $removePrefix: ['averagePrices'],
+  },
+  IdleScheduler: {
+    $removePrefix: ['tasks'],
+  },
+  Auction: {
+    $removePrefix: ['auctionEndTime'],
   },
 })
 

--- a/packages/networks/src/chains/hydration.ts
+++ b/packages/networks/src/chains/hydration.ts
@@ -27,6 +27,15 @@ const getInitStorages = (config: typeof custom.hydration | typeof custom.basilis
       [[defaultAccounts.alice.address, config.dai], { free: 100n * 10n ** 18n }],
     ],
   },
+  // MultiTransactionPayment.on_initialize iterates every AcceptedCurrencies entry (~91 on
+  // Hydration) and writes an AcceptedCurrencyPrice per entry, each block. Against a fork that is
+  // ~184 remote getKeysPaged calls per block, the bulk of the RPC traffic that makes bootstrap
+  // sensitive to transient upstream stalls. The fee-currency data is unused by these tests, so
+  // elide both maps; an exact-prefix removal lets the runtime iteration resolve locally instead
+  // of walking the upstream endpoint.
+  MultiTransactionPayment: {
+    $removePrefix: ['acceptedCurrencies', 'acceptedCurrencyPrice'],
+  },
 })
 
 export const hydration = defineChain({

--- a/packages/networks/src/chains/hydration.ts
+++ b/packages/networks/src/chains/hydration.ts
@@ -17,6 +17,12 @@ const custom = {
   },
 }
 
+// Shared across Hydration and Basilisk. `MultiTransactionPayment.on_initialize` iterates every
+// AcceptedCurrencies entry and writes an AcceptedCurrencyPrice per entry, each block. Against a
+// fork that is a large batch of remote getKeysPaged calls per block, the bulk of the RPC traffic
+// that makes bootstrap sensitive to transient upstream stalls. The fee-currency data is unused by
+// these tests, so elide both maps; an exact-prefix removal lets the runtime iteration resolve
+// locally instead of walking the upstream endpoint.
 const getInitStorages = (config: typeof custom.hydration | typeof custom.basilisk) => ({
   System: {
     Account: [[[defaultAccountsSr25519.alice.address], { providers: 1, data: { free: 10n ** 18n } }]],
@@ -27,21 +33,19 @@ const getInitStorages = (config: typeof custom.hydration | typeof custom.basilis
       [[defaultAccounts.alice.address, config.dai], { free: 100n * 10n ** 18n }],
     ],
   },
-  // MultiTransactionPayment.on_initialize iterates every AcceptedCurrencies entry (~91 on
-  // Hydration) and writes an AcceptedCurrencyPrice per entry, each block. Against a fork that is
-  // ~184 remote getKeysPaged calls per block, the bulk of the RPC traffic that makes bootstrap
-  // sensitive to transient upstream stalls. The fee-currency data is unused by these tests, so
-  // elide both maps; an exact-prefix removal lets the runtime iteration resolve locally instead
-  // of walking the upstream endpoint.
   MultiTransactionPayment: {
     $removePrefix: ['acceptedCurrencies', 'acceptedCurrencyPrice'],
   },
-  // Omnipool block hooks iterate the Assets map each block; it is unused by the transfer tests
-  // and eliding it removes another ~21 remote getKeysPaged calls per block.
+})
+
+const hydrationInitStorages = {
+  ...getInitStorages(custom.hydration),
+  // Hydration-only (Basilisk has no Omnipool): its block hooks iterate the Assets map each block,
+  // ~21 remote getKeysPaged calls per block. Unused by the transfer tests, so elide it.
   Omnipool: {
     $removePrefix: ['assets'],
   },
-})
+}
 
 export const hydration = defineChain({
   name: 'hydration',
@@ -49,7 +53,7 @@ export const hydration = defineChain({
   endpoint: endpoints.hydration,
   networkGroup: 'polkadot',
   custom: custom.hydration,
-  initStorages: getInitStorages(custom.hydration),
+  initStorages: hydrationInitStorages,
   properties: {
     addressEncoding: 0,
     schedulerBlockProvider: 'Local',

--- a/packages/networks/src/chains/hydration.ts
+++ b/packages/networks/src/chains/hydration.ts
@@ -36,6 +36,11 @@ const getInitStorages = (config: typeof custom.hydration | typeof custom.basilis
   MultiTransactionPayment: {
     $removePrefix: ['acceptedCurrencies', 'acceptedCurrencyPrice'],
   },
+  // Omnipool block hooks iterate the Assets map each block; it is unused by the transfer tests
+  // and eliding it removes another ~21 remote getKeysPaged calls per block.
+  Omnipool: {
+    $removePrefix: ['assets'],
+  },
 })
 
 export const hydration = defineChain({


### PR DESCRIPTION
## What

Several parachain runtimes iterate large storage maps in their block hooks every block. Against a Chopsticks fork, each iteration step is a remote getKeysPaged, so every block build fires hundreds of upstream calls. When one exceeds Subway's 90s timeout during a transient upstream stall, setupNetworks throws and the whole suite fails. This is the root cause of the recurrent acala.hydration / acala.* / hydration.* failures in the known-good update workflow.

Elide the maps that are iterated per block but unused by the tests, via `$removePrefix`:

Hydration (shared with Basilisk where the pallet exists):
- MultiTransactionPayment.AcceptedCurrencies + AcceptedCurrencyPrice

Hydration only (Basilisk has no Omnipool pallet):
- Omnipool.Assets

Acala + Karura (shared runtime):
- Rewards.PoolInfos, Incentives.IncentiveRewardAmounts (Incentives.on_initialize)
- DexOracle.AveragePrices (every block)
- IdleScheduler.Tasks (on_idle)
- Auction.AuctionEndTime

## Why it works

Chopsticks skips the remote key-discovery probe when a deleted prefix exactly matches the iterated storage item, so the runtime's iteration resolves locally.

## Measured impact (traced)

- acala.hydration.xcm: getKeysPaged 800 -> 109
- acala.accounts.e2e: getKeysPaged 245 -> 58
- all targeted per-block iteration storms eliminated (0)
- tests pass, snapshots unchanged (behaviour identical)

## Validation

- acala.hydration, acala.assetHubPolkadot, acala.moonbeam, karura.accounts, karura.shiden, karura.preimage: 65 passed, 6 skipped
- basilisk.preimage, basilisk.karura: 16 passed (fixes the Omnipool pallet-not-found error from scoping)
- hydration.moonbeam, bifrostPolkadot.hydration, hydration.accounts: 44 passed, 3 skipped

Diagnostic method: fork each chain, run with LOG_LEVEL=trace, tally remote getKeysPaged by storage prefix decoded against live metadata, bucket by block-build phase. Acala's per-block iterators independently confirmed against the runtime source.