### PR TITLE
Anchor synthetic remote proxy roots at the true relay parent

### DIFF
--- a/packages/shared/src/remoteProxy.ts
+++ b/packages/shared/src/remoteProxy.ts
@@ -56,16 +56,27 @@ async function buildSyntheticProxyProof(
 }
 
 /**
- * Replace the most recent relay state root in the pallet's `BlockToRoot` storage with a synthetic one.
+ * Insert a synthetic relay state root into the pallet's `BlockToRoot` storage, keyed at the
+ * actual relay parent block.
  *
  * The pallet stores a bounded vector of `(relay_block, state_root)` pairs that it uses to verify
- * incoming proofs. This function reads the current entries, swaps the state root of the last entry
- * with the given `trieRootHash`, and writes the result back via `dev.setStorage`.
+ * incoming proofs. This function replaces the vector's last entry with
+ * `(parachainSystem.lastRelayChainBlockNumber, trieRootHash)` and writes the result back via
+ * `dev.setStorage`.
+ *
+ * The entry is keyed at the actual relay parent rather than the last stored `BlockToRoot` key
+ * because the two can diverge on-chain: with multiple parachain blocks per relay block, the
+ * bounded vector saturates with entries younger than the pallet's pruning cutoff, and its silent
+ * `try_push` failure lets the stored keys lag the true relay parent (observed up to 6 blocks on
+ * Kusama Asset Hub). An anchor keyed at a lagged block gets pruned when the next Chopsticks block
+ * advances the relay parent, and the extrinsic then fails with `UnknownProofAnchorBlock`. Keying
+ * at the true relay parent keeps the anchor inside the pruning window regardless of lag.
  *
  * Raw storage injection is necessary because `BlockToRoot` is keyed by a generic pallet instance
  * parameter, which the high-level `dev.setStorage({ PalletName: ... })` API does not support.
  *
- * @returns The relay block number whose root was replaced (to be used as the proof's anchor block).
+ * @returns The relay block number the synthetic root was keyed at (to be used as the proof's
+ * anchor block).
  */
 async function injectSyntheticRoot(
   client: { api: any; dev: any },
@@ -81,11 +92,14 @@ async function injectSyntheticRoot(
 
   assert(blockToRoot.length > 0, 'BlockToRoot should not be empty after building a block')
 
-  const lastRelayBlock = blockToRoot[blockToRoot.length - 1][0]
-
-  const updatedBlockToRoot = blockToRoot.map(([block, hash]) =>
-    block === lastRelayBlock ? [block, trieRootHash] : [block, hash],
+  const lastRelayBlock = (await client.api.query.parachainSystem.lastRelayChainBlockNumber()).toNumber()
+  const lastStoredBlock = blockToRoot[blockToRoot.length - 1][0]
+  assert(
+    lastRelayBlock >= lastStoredBlock,
+    `BlockToRoot last entry (${lastStoredBlock}) is ahead of the relay parent (${lastRelayBlock})`,
   )
+
+  const updatedBlockToRoot = [...blockToRoot.slice(0, -1), [lastRelayBlock, trieRootHash] as [number, string]]
 
   const encodedEntries = updatedBlockToRoot.map(([block, hash]) =>
     u8aConcat(new Uint8Array(new Uint32Array([block as number]).buffer), hexToU8a(hash as string)),


### PR DESCRIPTION
## Problem

`Tests (kusama, shard 2/3)` in the scheduled Update Known Good Block Numbers workflow failed in three of the last five runs ([29833774560](https://github.com/open-web3-stack/polkadot-ecosystem-tests/actions/runs/29833774560), [29884062319](https://github.com/open-web3-stack/polkadot-ecosystem-tests/actions/runs/29884062319), [29902845087](https://github.com/open-web3-stack/polkadot-ecosystem-tests/actions/runs/29902845087)). Each time, the same 13 tests in `assetHubKusama.remoteProxy.e2e.test.ts` fail with `UnknownProofAnchorBlock`.

`injectSyntheticRoot` keys the synthetic root at the last entry of the pallet's `BlockToRoot` storage value. On Kusama Asset Hub that entry can lag `parachainSystem.lastRelayChainBlockNumber` by up to 6 blocks. Since runtimes 2.3.0 switched the chain to 24s Aura slots (polkadot-fellows/runtimes#1174), several parachain blocks are produced per relay block, and the pallet's bounded vector (capacity 10, `MaxStorageRootsToKeep`) fills with entries too young to be pruned. Its `try_push` of new roots then fails silently (`debug_assert!` only), so the stored keys fall behind the relay parent.

When the test builds the next block, Chopsticks advances the relay parent by 4 (24s Aura slot / 6s relay slot). The pallet prunes entries older than `parent - 10`, which deletes an anchor keyed 6 blocks back before the extrinsic executes. The failure occurs exactly when the pinned block was captured at lag 6:

| Pinned AHK block | `BlockToRoot` last | Relay parent | Lag | Result |
|---|---|---|---|---|
| 19295078 | 34471290 | 34471296 | 6 | 13 failed |
| 19315869 | 34478562 | 34478568 | 6 | 13 failed |
| 19326433 | 34482255 | 34482261 | 6 | 13 failed |
| 19286333 | 34468289 | 34468289 | 0 | passed |
| 19304697 | 34474672 | 34474672 | 0 | passed |

## Fix

Key the injected entry at `parachainSystem.lastRelayChainBlockNumber` instead of the last stored `BlockToRoot` key. The anchor then always sits inside the pruning window, regardless of on-chain lag. The entry replaces the last one rather than being appended, so the vector stays within its bound and in ascending order; an added `assert` guards the ordering invariant.

With this change the suite passes 16/16 at all five pins above. At lag-0 pins the old and new code pick the same anchor, so behavior there is unchanged. No snapshot updates needed.

## Note

The storage lag itself is a runtime issue: during lag windows, real `remote_proxy` calls anchored at recent relay blocks also fail on chain, and effective root retention is 3-4 relay blocks instead of the configured 10. To be reported separately to polkadot-fellows/runtimes.
