### PR TITLE
ci: support Acala endpoint override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,15 +71,22 @@ jobs:
           cat "$ENV_FILE" >> $GITHUB_ENV
 
       - name: Start all Subway instances
+        env:
+          ACALA_ENDPOINT: ${{ secrets.ACALA_ENDPOINT }}
         run: |
           echo "Starting all Subway instances for ${{ matrix.network.name }}..."
 
           echo '${{ toJSON(matrix.network.chains) }}' | jq -c '.[]' | while read chain; do
             CHAIN=$(echo $chain | jq -r '.chain')
             PORT=$(echo $chain | jq -r '.port')
+            ENDPOINT_VAR=$(echo $chain | jq -r '.endpoint_var')
+            ENDPOINT_OVERRIDE="${!ENDPOINT_VAR:-}"
 
-            # Get endpoints from pet-chain-endpoints.json
-            ENDPOINTS=$(jq -c ".$CHAIN" packages/networks/src/pet-chain-endpoints.json)
+            if [ -n "$ENDPOINT_OVERRIDE" ]; then
+              ENDPOINTS=$(jq -cn --arg endpoint "$ENDPOINT_OVERRIDE" '[$endpoint]')
+            else
+              ENDPOINTS=$(jq -c ".$CHAIN" packages/networks/src/pet-chain-endpoints.json)
+            fi
 
             if [ "$ENDPOINTS" = "null" ] || [ -z "$ENDPOINTS" ]; then
               echo "Error: No endpoints found for chain $CHAIN"

--- a/.github/workflows/update-known-good.yml
+++ b/.github/workflows/update-known-good.yml
@@ -42,8 +42,9 @@ jobs:
         id: networks
         run: echo "networks=$(node scripts/generate-ci-matrix.mjs)" >> "$GITHUB_OUTPUT"
       - name: Update Known Good Block Numbers
-        run: |
-          yarn update-known-good
+        env:
+          ACALA_ENDPOINT: ${{ secrets.ACALA_ENDPOINT }}
+        run: yarn update-known-good
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -101,15 +102,22 @@ jobs:
 
       # Start one Subway instance per chain in this network, each on its own port
       - name: Start all Subway instances
+        env:
+          ACALA_ENDPOINT: ${{ secrets.ACALA_ENDPOINT }}
         run: |
           echo "Starting all Subway instances for ${{ matrix.network.name }}..."
 
           echo '${{ toJSON(matrix.network.chains) }}' | jq -c '.[]' | while read chain; do
             CHAIN=$(echo $chain | jq -r '.chain')
             PORT=$(echo $chain | jq -r '.port')
+            ENDPOINT_VAR=$(echo $chain | jq -r '.endpoint_var')
+            ENDPOINT_OVERRIDE="${!ENDPOINT_VAR:-}"
 
-            # Get endpoints from pet-chain-endpoints.json
-            ENDPOINTS=$(jq -c ".$CHAIN" packages/networks/src/pet-chain-endpoints.json)
+            if [ -n "$ENDPOINT_OVERRIDE" ]; then
+              ENDPOINTS=$(jq -cn --arg endpoint "$ENDPOINT_OVERRIDE" '[$endpoint]')
+            else
+              ENDPOINTS=$(jq -c ".$CHAIN" packages/networks/src/pet-chain-endpoints.json)
+            fi
 
             if [ "$ENDPOINTS" = "null" ] || [ -z "$ENDPOINTS" ]; then
               echo "Error: No endpoints found for chain $CHAIN"

--- a/.github/workflows/update-snapshot.yml
+++ b/.github/workflows/update-snapshot.yml
@@ -50,6 +50,8 @@ jobs:
         subway --version
 
     - name: Update known good block numbers
+      env:
+        ACALA_ENDPOINT: ${{ secrets.ACALA_ENDPOINT }}
       run: yarn update-known-good
 
     - name: Source known good block numbers
@@ -60,15 +62,22 @@ jobs:
         cat "$ENV_FILE" >> $GITHUB_ENV
 
     - name: Start all Subway instances
+      env:
+        ACALA_ENDPOINT: ${{ secrets.ACALA_ENDPOINT }}
       run: |
         echo "Starting all Subway instances for ${{ matrix.network.name }}..."
 
         echo '${{ toJSON(matrix.network.chains) }}' | jq -c '.[]' | while read chain; do
           CHAIN=$(echo $chain | jq -r '.chain')
           PORT=$(echo $chain | jq -r '.port')
+          ENDPOINT_VAR=$(echo $chain | jq -r '.endpoint_var')
+          ENDPOINT_OVERRIDE="${!ENDPOINT_VAR:-}"
 
-          # Get endpoints from pet-chain-endpoints.json
-          ENDPOINTS=$(jq -c ".$CHAIN" packages/networks/src/pet-chain-endpoints.json)
+          if [ -n "$ENDPOINT_OVERRIDE" ]; then
+            ENDPOINTS=$(jq -cn --arg endpoint "$ENDPOINT_OVERRIDE" '[$endpoint]')
+          else
+            ENDPOINTS=$(jq -c ".$CHAIN" packages/networks/src/pet-chain-endpoints.json)
+          fi
 
           if [ "$ENDPOINTS" = "null" ] || [ -z "$ENDPOINTS" ]; then
             echo "Error: No endpoints found for chain $CHAIN"

--- a/packages/polkadot/src/__snapshots__/acala.assetHubPolkadot.xcm.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/acala.assetHubPolkadot.xcm.test.ts.snap
@@ -110,7 +110,7 @@ exports[`acala & assetHubPolkadot > acala transfer DOT to assetHubPolkadot > to 
       "success": true,
       "weightUsed": {
         "proofSize": "(rounded 10000)",
-        "refTime": "(rounded 500000000)",
+        "refTime": "(rounded 400000000)",
       },
     },
     "method": "Processed",
@@ -280,7 +280,7 @@ exports[`acala & assetHubPolkadot > acala transfer DOT to assetHubPolkadot with 
       "success": false,
       "weightUsed": {
         "proofSize": "(rounded 10000)",
-        "refTime": "(rounded 500000000)",
+        "refTime": "(rounded 400000000)",
       },
     },
     "method": "Processed",
@@ -726,7 +726,7 @@ exports[`acala & assetHubPolkadot > acala transfer USDT to assetHubPolkadot > to
       "success": true,
       "weightUsed": {
         "proofSize": "(rounded 10000)",
-        "refTime": "(rounded 500000000)",
+        "refTime": "(rounded 400000000)",
       },
     },
     "method": "Processed",
@@ -975,7 +975,7 @@ exports[`acala & assetHubPolkadot > assetHubPolkadot transfer ETH to acala > tx 
         "Complete": {
           "used": {
             "proofSize": "(rounded 6000)",
-            "refTime": "(rounded 300000000)",
+            "refTime": "(rounded 200000000)",
           },
         },
       },
@@ -1261,7 +1261,7 @@ exports[`acala & assetHubPolkadot > assetHubPolkadot transfer USDT to acala > tx
         "Complete": {
           "used": {
             "proofSize": "(rounded 6000)",
-            "refTime": "(rounded 300000000)",
+            "refTime": "(rounded 200000000)",
           },
         },
       },

--- a/packages/polkadot/src/__snapshots__/acala.assetHubPolkadot.xcm.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/acala.assetHubPolkadot.xcm.test.ts.snap
@@ -110,7 +110,7 @@ exports[`acala & assetHubPolkadot > acala transfer DOT to assetHubPolkadot > to 
       "success": true,
       "weightUsed": {
         "proofSize": "(rounded 10000)",
-        "refTime": "(rounded 400000000)",
+        "refTime": "(rounded 500000000)",
       },
     },
     "method": "Processed",
@@ -169,7 +169,7 @@ exports[`acala & assetHubPolkadot > acala transfer DOT to assetHubPolkadot > tx 
 
 exports[`acala & assetHubPolkadot > acala transfer DOT to assetHubPolkadot with limited weight > balance on from chain 1`] = `
 {
-  "free": 9000000000000,
+  "free": 8000000000000,
   "frozen": 0,
   "reserved": 0,
 }
@@ -180,12 +180,12 @@ exports[`acala & assetHubPolkadot > acala transfer DOT to assetHubPolkadot with 
   "consumers": 0,
   "data": {
     "flags": "0x80000000000000000000000000000000",
-    "free": 0,
+    "free": "(rounded 1000000000000)",
     "frozen": 0,
     "reserved": 0,
   },
   "nonce": 0,
-  "providers": 0,
+  "providers": 1,
   "sufficients": 0,
 }
 `;
@@ -280,7 +280,7 @@ exports[`acala & assetHubPolkadot > acala transfer DOT to assetHubPolkadot with 
       "success": false,
       "weightUsed": {
         "proofSize": "(rounded 10000)",
-        "refTime": "(rounded 400000000)",
+        "refTime": "(rounded 500000000)",
       },
     },
     "method": "Processed",
@@ -726,7 +726,7 @@ exports[`acala & assetHubPolkadot > acala transfer USDT to assetHubPolkadot > to
       "success": true,
       "weightUsed": {
         "proofSize": "(rounded 10000)",
-        "refTime": "(rounded 400000000)",
+        "refTime": "(rounded 500000000)",
       },
     },
     "method": "Processed",
@@ -975,7 +975,7 @@ exports[`acala & assetHubPolkadot > assetHubPolkadot transfer ETH to acala > tx 
         "Complete": {
           "used": {
             "proofSize": "(rounded 6000)",
-            "refTime": "(rounded 200000000)",
+            "refTime": "(rounded 300000000)",
           },
         },
       },
@@ -1261,7 +1261,7 @@ exports[`acala & assetHubPolkadot > assetHubPolkadot transfer USDT to acala > tx
         "Complete": {
           "used": {
             "proofSize": "(rounded 6000)",
-            "refTime": "(rounded 200000000)",
+            "refTime": "(rounded 300000000)",
           },
         },
       },

--- a/packages/polkadot/src/__snapshots__/acala.astar.xcm.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/acala.astar.xcm.test.ts.snap
@@ -366,7 +366,7 @@ exports[`acala & astar > acala transfer DOT to astar > route chain xcm events 1`
       "success": true,
       "weightUsed": {
         "proofSize": "(rounded 10000)",
-        "refTime": "(rounded 700000000)",
+        "refTime": "(rounded 600000000)",
       },
     },
     "method": "Processed",
@@ -818,7 +818,7 @@ exports[`acala & astar > astar transfer DOT to acala > route chain xcm events 1`
       "success": true,
       "weightUsed": {
         "proofSize": "(rounded 10000)",
-        "refTime": "(rounded 700000000)",
+        "refTime": "(rounded 600000000)",
       },
     },
     "method": "Processed",

--- a/packages/polkadot/src/__snapshots__/acala.astar.xcm.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/acala.astar.xcm.test.ts.snap
@@ -126,6 +126,13 @@ exports[`acala & astar > acala transfer ACA to astar > to chain xcm events 1`] =
 [
   {
     "data": {
+      "messageHash": "(hash)",
+    },
+    "method": "XcmpMessageSent",
+    "section": "xcmpQueue",
+  },
+  {
+    "data": {
       "id": "(hash)",
       "origin": {
         "Sibling": 2000,
@@ -359,7 +366,7 @@ exports[`acala & astar > acala transfer DOT to astar > route chain xcm events 1`
       "success": true,
       "weightUsed": {
         "proofSize": "(rounded 10000)",
-        "refTime": "(rounded 600000000)",
+        "refTime": "(rounded 700000000)",
       },
     },
     "method": "Processed",
@@ -372,6 +379,13 @@ exports[`acala & astar > acala transfer DOT to astar > to chain xcm events 1`] =
 [
   {
     "data": {
+      "messageHash": "(hash)",
+    },
+    "method": "XcmpMessageSent",
+    "section": "xcmpQueue",
+  },
+  {
+    "data": {
       "id": "(hash)",
       "origin": {
         "Sibling": 1000,
@@ -380,6 +394,21 @@ exports[`acala & astar > acala transfer DOT to astar > to chain xcm events 1`] =
       "weightUsed": {
         "proofSize": "(rounded 9000)",
         "refTime": "(rounded 900000000)",
+      },
+    },
+    "method": "Processed",
+    "section": "messageQueue",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "origin": {
+        "Sibling": 2000,
+      },
+      "success": true,
+      "weightUsed": {
+        "proofSize": "(rounded 3000)",
+        "refTime": "(rounded 30000000)",
       },
     },
     "method": "Processed",
@@ -789,7 +818,7 @@ exports[`acala & astar > astar transfer DOT to acala > route chain xcm events 1`
       "success": true,
       "weightUsed": {
         "proofSize": "(rounded 10000)",
-        "refTime": "(rounded 600000000)",
+        "refTime": "(rounded 700000000)",
       },
     },
     "method": "Processed",
@@ -810,6 +839,28 @@ exports[`acala & astar > astar transfer DOT to acala > to chain xcm events 1`] =
       "weightUsed": {
         "proofSize": 0,
         "refTime": 1000000000,
+      },
+    },
+    "method": "Processed",
+    "section": "messageQueue",
+  },
+  {
+    "data": {
+      "messageHash": "(hash)",
+    },
+    "method": "XcmpMessageSent",
+    "section": "xcmpQueue",
+  },
+  {
+    "data": {
+      "id": "(hash)",
+      "origin": {
+        "Sibling": "(rounded 2000)",
+      },
+      "success": true,
+      "weightUsed": {
+        "proofSize": 0,
+        "refTime": 200000000,
       },
     },
     "method": "Processed",

--- a/packages/polkadot/src/__snapshots__/acala.hydration.xcm.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/acala.hydration.xcm.test.ts.snap
@@ -142,7 +142,7 @@ exports[`acala & hydration > acala transfer DOT to hydration > route chain xcm e
       "success": true,
       "weightUsed": {
         "proofSize": "(rounded 10000)",
-        "refTime": "(rounded 700000000)",
+        "refTime": "(rounded 600000000)",
       },
     },
     "method": "Processed",

--- a/packages/polkadot/src/__snapshots__/acala.hydration.xcm.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/acala.hydration.xcm.test.ts.snap
@@ -142,7 +142,7 @@ exports[`acala & hydration > acala transfer DOT to hydration > route chain xcm e
       "success": true,
       "weightUsed": {
         "proofSize": "(rounded 10000)",
-        "refTime": "(rounded 600000000)",
+        "refTime": "(rounded 700000000)",
       },
     },
     "method": "Processed",

--- a/packages/polkadot/src/acala.accounts.e2e.test.ts
+++ b/packages/polkadot/src/acala.accounts.e2e.test.ts
@@ -22,7 +22,4 @@ const accountsCfg = createAccountsConfig({
   },
 })
 
-// Skipped: the Acala fork setup intermittently times out (RpcError -32603). Skipping via the tree
-// flag means the describe's beforeAll (which forks Acala) never runs, so the flake is avoided while
-// the suite's snapshots stay owned. Remove the flag to re-enable.
-registerTestTree({ ...accountsE2ETests(acala, testConfig, accountsCfg), flags: { skip: true } })
+registerTestTree(accountsE2ETests(acala, testConfig, accountsCfg))

--- a/packages/polkadot/src/acala.assetHubPolkadot.xcm.test.ts
+++ b/packages/polkadot/src/acala.assetHubPolkadot.xcm.test.ts
@@ -7,10 +7,7 @@ import { runXcmPalletHorizontal, runXtokenstHorizontal } from '@e2e-test/shared/
 
 import { beforeAll, describe } from 'vitest'
 
-// Skipped: Acala fork setup intermittently times out (RpcError -32603), flaking CI. See #660.
-// Network setup lives in beforeAll so that describe.skip actually prevents it from running (an
-// async describe factory would run at collection time regardless of skip).
-describe.skip('acala & assetHubPolkadot', () => {
+describe('acala & assetHubPolkadot', () => {
   let assetHubPolkadotClient: Client
   let acalaClient: Client
 

--- a/packages/polkadot/src/acala.astar.xcm.test.ts
+++ b/packages/polkadot/src/acala.astar.xcm.test.ts
@@ -7,10 +7,7 @@ import { runXtokenstHorizontal } from '@e2e-test/shared/xcm'
 
 import { beforeAll, describe } from 'vitest'
 
-// Skipped: Acala fork setup intermittently times out (RpcError -32603), flaking CI. See #660.
-// Network setup lives in beforeAll so that describe.skip actually prevents it from running (an
-// async describe factory would run at collection time regardless of skip).
-describe.skip('acala & astar', () => {
+describe('acala & astar', () => {
   let astarClient: Client
   let acalaClient: Client
   let assetHubPolkadotClient: Client

--- a/packages/polkadot/src/acala.hydration.xcm.test.ts
+++ b/packages/polkadot/src/acala.hydration.xcm.test.ts
@@ -7,10 +7,7 @@ import { runXtokenstHorizontal } from '@e2e-test/shared/xcm'
 
 import { beforeAll, describe } from 'vitest'
 
-// Skipped: Acala fork setup intermittently times out (RpcError -32603), flaking CI. See #660.
-// Network setup lives in beforeAll so that describe.skip actually prevents it from running (an
-// async describe factory would run at collection time regardless of skip).
-describe.skip('acala & hydration', () => {
+describe('acala & hydration', () => {
   let acalaClient: Client
   let hydrationClient: Client
   let assetHubPolkadotClient: Client

--- a/packages/polkadot/src/acala.moonbeam.xcm.test.ts
+++ b/packages/polkadot/src/acala.moonbeam.xcm.test.ts
@@ -7,9 +7,6 @@ import { runXcmPalletHorizontal, runXtokenstHorizontal } from '@e2e-test/shared/
 
 import { beforeAll, describe } from 'vitest'
 
-// Skipped: Acala fork setup intermittently times out (RpcError -32603), flaking CI. See #660.
-// Network setup lives in beforeAll so that describe.skip actually prevents it from running (an
-// async describe factory would run at collection time regardless of skip).
 describe.skip('acala & moonbeam', () => {
   // TODO: until we figured out how to query balances on Moonbeam again
   let acalaClient: Client


### PR DESCRIPTION
Closes #660

Adds support for using a secret Acala RPC endpoint in CI to avoid intermittent fork setup timeouts.

### Changes
- Expose the `ACALA_ENDPOINT` secret to CI, snapshot update, and known-good block workflows.
- Resolve per-chain endpoint overrides from each matrix entry’s `endpoint_var`, falling back to the configured public endpoints when no override is set.
- Re-enable the Acala accounts, Asset Hub, Astar, and Hydration test suites.
- Update Acala XCM snapshots to reflect current balances, events, and execution weights.