### PR TITLE
Simplify CLAUDE.md and lead with authoring rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,14 @@ Guidance for working in this repo. Read the rules before writing code.
 5. Clarity over abstraction. Do not add helpers that hide what a test does. Mild repetition that keeps intent legible beats a clever helper that muddles it.
 6. Validate before you claim. Confirm against runtime source, live chain, or a fork run. Never assert from memory or one possibly-stale read.
 
+## Authoring tests
+
+`staking.ts`, `multisig.ts`, `proxy.ts`, and `scheduler.ts` are the reference suites. Read them before writing a new one.
+
+- Coverage: for a pallet, exercise its dispatchables, the events they emit, and their error paths. Test the failure cases (bad origin, wrong state, ineligible caller), not just the happy path.
+- Documentation: give each test function a docstring that names what it checks and enumerates the flow as numbered steps. Then repeat those step markers as comments through the body, next to the code each step describes, so the flow reads top to bottom.
+- Wording: clear and simple. See rule 3.
+
 ## Overview
 
 Automated test suite for Polkadot/Kusama, powered by [Chopsticks](https://github.com/AcalaNetwork/chopsticks). Tests XCM transfers and end-to-end scenarios for relay chains and system parachains.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,140 +1,62 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Guidance for working in this repo. Read the rules before writing code.
+
+## Rules
+
+1. Write simply, plainly, concisely. No em-dashes. No US-centric filler, no startup fluff. Say the thing.
+2. Match the prior art. Read existing suites to see how test trees are structured, documented, and written, then follow it.
+3. Comment your code, and make comments stand alone. Use the repo's style. A comment must make sense without the PR, the issue, or your working context. No verbatim external text, no contrasts against things the reader cannot see.
+4. Assert on contents, not existence. Decode events and state with typed checks and scrutinize their fields. Do not snapshot bare event names or check only that something fired.
+5. Clarity over abstraction. Do not add helpers that hide what a test does. Mild repetition that keeps intent legible beats a clever helper that muddles it.
+6. Validate before you claim. Confirm against runtime source, live chain, or a fork run. Never assert from memory or one possibly-stale read.
 
 ## Overview
 
-Polkadot Ecosystem Tests is an automated testing suite for Polkadot/Kusama networks powered by [Chopsticks](https://github.com/AcalaNetwork/chopsticks). It tests XCM transfers between chains and end-to-end scenarios for relay chains and system parachains.
+Automated test suite for Polkadot/Kusama, powered by [Chopsticks](https://github.com/AcalaNetwork/chopsticks). Tests XCM transfers and end-to-end scenarios for relay chains and system parachains.
 
 ## Commands
 
 ```bash
-# Install dependencies
-yarn install
-
-# Run all tests
-yarn test
-
-# Run tests for a specific network
-yarn test:polkadot
-yarn test:kusama
-
-# Run tests matching a pattern (test name from describe/it blocks)
-yarn test -t <test-name>
-
-# Run tests for a specific chain file
-yarn test <chain>
-
-# Run with Vitest UI
-yarn test:ui
-
-# Update snapshots (after test changes or intentional behavior changes)
-yarn test -u
-
-# Lint and type check
-yarn lint
-
-# Auto-fix lint issues
-yarn fix
-
-# Update block numbers to latest
-yarn update-known-good      # Update KNOWN_GOOD_BLOCK_NUMBERS_*.env (used by CI)
-yarn update-env             # Update local .env
-
-# Check proxy test coverage
-yarn check-proxy-coverage
+yarn test                   # all tests
+yarn test:polkadot          # one network
+yarn test <chain>           # one chain file
+yarn test -t <test-name>    # by test name
+yarn test -u                # update snapshots
+yarn lint                   # tsc + biome
+yarn fix                    # auto-fix lint
+yarn update-known-good      # refresh CI block numbers
 ```
 
-## Architecture
+## Layout
 
-### Package Structure
+- `packages/shared/src/*.ts`: E2E test suites (network-agnostic logic lives here)
+- `packages/shared/src/xcm/`: XCM runners
+- `packages/shared/src/helpers/`: utilities and assertion helpers
+- `packages/networks/src/chains/`: chain definitions
+- `packages/{polkadot,kusama}/src/`: per-network test files that import the shared suites
 
-- **packages/shared**: All E2E test suites and shared utilities
-  - `src/*.ts`: E2E test modules (accounts, bounties, governance, multisig, proxy, staking, vesting, etc.)
-  - `src/xcm/`: XCM test runners (`runXcmPalletUp`, `runXcmPalletDown`, `runXcmPalletHorizontal`)
-  - `src/helpers/`: Test utilities and assertion helpers
+File names: `<a>.<b>.xcm.test.ts` for XCM, `<chain>.<suite>.e2e.test.ts` for E2E. Required for failure reporting.
 
-- **packages/networks**: Chain configurations
-  - `src/chains/`: Chain definitions (polkadot, kusama, assetHub, bridgeHub, coretime, people, etc.)
+## Key utilities
 
-- **packages/polkadot**: Polkadot network test files (import shared tests)
-- **packages/kusama**: Kusama network test files (import shared tests)
+- `setupNetworks(...chains)`: connected contexts with snapshot restore between tests
+- `createNetworks(...chains)`: lower-level network creation
+- `sendTransaction(tx)`, `client.dev.newBlock()`, `client.dev.setStorage()`
+- `scheduleInlineCallWithOrigin()`: privileged calls via the scheduler
+- `createXcmTransactSend()`: XCM Transact to a parachain
+- `check()`, `checkEvents()`, `checkSystemEvents()`: snapshot helpers with `.redact()`
+- `assertExpectedEvents()`: typed event assertion with per-field matchers (see rule 4)
+- Accounts: `defaultAccounts`, `defaultAccountsSr25519`, `testAccounts` from `@e2e-test/networks`
 
-### Key Utilities
+## Environment
 
-- `setupNetworks(...chains)`: Creates connected Chopsticks test contexts with automatic snapshot restore between tests
-- `createNetworks(...chains)`: Lower-level function to create multiple connected networks (relay + parachains)
-- `sendTransaction(tx)`: From `@acala-network/chopsticks-testing`, sends a transaction
-- `client.dev.newBlock()`: Advances the chain by one block
-- `client.dev.setStorage()`: Directly manipulates chain storage for test setup
-- `scheduleInlineCallWithOrigin()`: Execute privileged calls (e.g., Root origin) via the scheduler pallet
-- `createXcmTransactSend()`: Send XCM Transact messages to execute calls in parachains
-- `check()`, `checkEvents()`, `checkSystemEvents()`: Snapshot assertion helpers with `.redact()` support
-- Test accounts: `defaultAccounts`, `defaultAccountsSr25519`, `testAccounts` (from `@e2e-test/networks`)
+Block numbers come from `KNOWN_GOOD_BLOCK_NUMBERS_{POLKADOT,KUSAMA}.env` (CI) or `.env` (local).
+Override per chain: `<NETWORK>_BLOCK_NUMBER`, `<NETWORK>_WASM`, `<NETWORK>_ENDPOINT`.
 
-### Test File Naming Convention
+## Caveats
 
-- XCM tests: `<chain-a>.<chain-b>.xcm.test.ts`
-- E2E tests: `<chain-name>.<test-suite>.e2e.test.ts`
-
-This naming is required for automated test failure reporting to work correctly.
-
-### Key Testing Patterns
-
-```typescript
-// Setup networks with automatic snapshot restore between tests
-const [polkadotClient, ahClient] = await setupNetworks(polkadot, assetHubPolkadot)
-
-// Send transactions
-import { sendTransaction } from '@acala-network/chopsticks-testing'
-await sendTransaction(tx.signAsync(signer))
-await client.dev.newBlock()
-
-// Snapshot testing with redaction
-await check(result).redact().toMatchSnapshot('description')
-check(result).redact({ number: 1 }).toMatchSnapshot()  // Keep 1 significant digit
-check(result).redact({ removeKeys: /timestamp|blockHash/ }).toMatchSnapshot()
-
-// Execute privileged calls via scheduler
-await scheduleInlineCallWithOrigin(client, encodedCall, { system: 'Root' })
-
-// Execute calls in parachain via XCM from relay
-const xcmSend = createXcmTransactSend(relayClient, dest, encodedCall, 'Superuser')
-```
-
-### Environment Configuration
-
-Block numbers are controlled via environment files:
-- `KNOWN_GOOD_BLOCK_NUMBERS_POLKADOT.env` / `KNOWN_GOOD_BLOCK_NUMBERS_KUSAMA.env`: Used by CI
-- `.env`: Local overrides
-
-Override specific chains: `<NETWORK>_BLOCK_NUMBER`, `<NETWORK>_WASM`, `<NETWORK>_ENDPOINT`
-
-## Test Writing Guidelines
-
-### Development Workflow
-
-When developing tests or exploring scenario ideas:
-- Run Chopsticks networks alongside Polkadot.js Apps for experimentation
-- Prefer snapshot testing: automatic redaction of time-sensitive data, efficient storage of detailed execution info, CI integration catches regressions
-- Be aware: `await client.dev.newBlock()` can take 1-10 seconds depending on CPU/network conditions
-
-### Best Practices
-
-- Write network-agnostic test logic in `packages/shared/src/`
-- Implement chain-specific test files in `packages/polkadot/` or `packages/kusama/`
-- Use `.redact()` for volatile values to prevent flaky tests
-- Use `{ only: true }` to isolate tests during debugging
-- Use `await chain.pause()` for state inspection (connect via Polkadot.js Apps)
-- Delete `__snapshots__` folders and run `yarn test -u` when renaming/removing tests
-
-### Debugging
-
-- Pause tests for inspection: `await chain.pause()` (port shown in STDOUT, connect via Polkadot.js Apps)
-- Modify `testTimeout` in `vitest.config.mts` for long-running tests (currently 300s)
-- Snapshot mismatches: verify uncommitted changes with `git status`, ensure snapshots are in git tree
-- RPC failures may indicate configuration issues (check endpoints, block numbers in env files)
-
-## Chopsticks Limitations
-
-Block execution throughput is limited to ~1-10 blocks/second locally. Tests requiring many blocks (referenda confirmation, unbonding) may not be practical here.
+- `client.dev.newBlock()` takes 1-10s. Block throughput is ~1-10 blocks/s locally, so scenarios needing many blocks (referenda confirmation, unbonding) are impractical without storage surgery.
+- Use `.redact()` for volatile values or snapshots go flaky.
+- Renaming or removing a test leaves obsolete snapshots: delete the `__snapshots__` entry and run `yarn test -u`.
+- `await chain.pause()` to inspect state via Polkadot.js Apps (port in stdout).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Override per chain: `<NETWORK>_BLOCK_NUMBER`, `<NETWORK>_WASM`, `<NETWORK>_ENDPO
 
 ## Caveats
 
-- `client.dev.newBlock()` takes 1-10s. Block throughput is ~1-10 blocks/s locally, so scenarios needing many blocks (referenda confirmation, unbonding) are impractical without storage surgery.
+- `client.dev.newBlock()` takes 1-10s each, so under 1 block/s locally. Scenarios needing many blocks (referenda confirmation, unbonding) are impractical without storage surgery.
 - Use `.redact()` for volatile values or snapshots go flaky.
 - Renaming or removing a test leaves obsolete snapshots: delete the `__snapshots__` entry and run `yarn test -u`.
 - `await chain.pause()` to inspect state via Polkadot.js Apps (port in stdout).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ File names: `<a>.<b>.xcm.test.ts` for XCM, `<chain>.<suite>.e2e.test.ts` for E2E
 - `scheduleInlineCallWithOrigin()`: privileged calls via the scheduler
 - `createXcmTransactSend()`: XCM Transact to a parachain
 - `check()`, `checkEvents()`, `checkSystemEvents()`: snapshot helpers with `.redact()`
-- `assertExpectedEvents()`: typed event assertion with per-field matchers (see rule 4)
+- `assertExpectedEvents()`: one way to satisfy rule 4; suites also assert fields directly with `event.<T>.is(...)`, `dispatchError.asModule`, and `expect()`
 - Accounts: `defaultAccounts`, `defaultAccountsSr25519`, `testAccounts` from `@e2e-test/networks`
 
 ## Environment

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,20 +4,19 @@ Guidance for working in this repo. Read the rules before writing code.
 
 ## Rules
 
-1. Write simply, plainly, concisely. No em-dashes. No US-centric filler, no startup fluff. Say the thing.
-2. Match the prior art. Read existing suites to see how test trees are structured, documented, and written, then follow it.
-3. Comment your code, and make comments stand alone. Use the repo's style. A comment must make sense without the PR, the issue, or your working context. No verbatim external text, no contrasts against things the reader cannot see.
-4. Assert on contents, not existence. Decode events and state with typed checks and scrutinize their fields. Do not snapshot bare event names or check only that something fired.
-5. Clarity over abstraction. Do not add helpers that hide what a test does. Mild repetition that keeps intent legible beats a clever helper that muddles it.
-6. Validate before you claim. Confirm against runtime source, live chain, or a fork run. Never assert from memory or one possibly-stale read.
+1. You MUST write simply, plainly, concisely. No em-dashes, no US-centric filler, no startup fluff. Say the thing.
+2. You MUST match the prior art. Read existing suites for how test trees are structured, documented, and written, then follow it.
+3. You MUST comment your code, and comments MUST stand alone. Use the repo's style. A comment MUST make sense without the PR, the issue, or your working context. No verbatim external text, no contrasts against things the reader cannot see.
+4. You MUST snapshot events in whole, never bare names or other degenerate projections (temporally contingent data invites false positives). You MUST also cast events to their proper types and assert on the relevant fields.
+5. You SHOULD prefer clarity over abstraction. You MUST NOT add helpers that hide what a test does; mild repetition that keeps intent legible beats a clever helper that muddles it.
+6. You MUST validate before you claim. Confirm against runtime source, live chain, or a fork run. Never assert from memory or one possibly-stale read.
 
 ## Authoring tests
 
 `staking.ts`, `multisig.ts`, `proxy.ts`, and `scheduler.ts` are the reference suites. Read them before writing a new one.
 
-- Coverage: for a pallet, exercise its dispatchables, the events they emit, and their error paths. Test the failure cases (bad origin, wrong state, ineligible caller), not just the happy path.
-- Documentation: give each test function a docstring that names what it checks and enumerates the flow as numbered steps. Then repeat those step markers as comments through the body, next to the code each step describes, so the flow reads top to bottom.
-- Wording: clear and simple. See rule 3.
+- Coverage: a pallet's tests SHOULD exercise its dispatchables, the events they emit, and their error paths, including failure cases (bad origin, wrong state, ineligible caller), not just the happy path.
+- Documentation: each test function SHOULD carry a docstring that names what it checks and enumerates the flow as numbered steps, with those step markers repeated as comments through the body next to the code each describes, so the flow reads top to bottom.
 
 ## Overview
 


### PR DESCRIPTION
Trims CLAUDE.md from 140 lines to ~55 and puts authoring guidance first.

## Why
The bulk of the previous file was command and architecture reference that duplicates the README and the code layout, while the guidance that actually affects how tests get written was buried at the bottom and easy to skip. In practice it was rarely followed.

## Changes
- Lead with six rules: plain writing, matching existing suites, self-contained comments, asserting on event/state contents rather than existence, preferring clarity over abstraction, and validating claims against source or a live run.
- Collapse the overlapping Development Workflow / Best Practices / Debugging sections into a single short Caveats list, keeping only the load-bearing facts (block throughput, redaction, obsolete snapshots, pause-for-inspection).
- Drop boilerplate and the verbose pattern block; keep a lean commands/layout/utilities/environment reference.
- Add `assertExpectedEvents` to the utilities list, since the assertion rule points at it.