### PR TITLE
Add Bulletin Polkadot to the system, upgrade and XCM suites

### DIFF
--- a/packages/polkadot/src/__snapshots__/assetHubPolkadot.bulletinPolkadot.collectivesPolkadot.upgrade.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/assetHubPolkadot.bulletinPolkadot.collectivesPolkadot.upgrade.e2e.test.ts.snap
@@ -1,0 +1,184 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`asset hub & bulletin & collectives > Asset Hub authorizes Bulletin upgrade via Collectives > collectives events emitted when sending xcm 1`] = `
+[
+  {
+    "data": {
+      "destination": {
+        "interior": {
+          "X1": [
+            {
+              "Parachain": 1000,
+            },
+          ],
+        },
+        "parents": 1,
+      },
+      "message": [
+        {
+          "UnpaidExecution": {
+            "checkOrigin": null,
+            "weightLimit": "Unlimited",
+          },
+        },
+        {
+          "Transact": {
+            "call": {
+              "encoded": "0x4000d9ea40c3d0e00fa36850427794d57d192be777751c390fc9693d780d00c59f60",
+            },
+            "fallbackMaxWeight": {
+              "proofSize": 10000,
+              "refTime": 500000000,
+            },
+            "originKind": "Xcm",
+          },
+        },
+      ],
+      "messageId": "(redacted)",
+      "origin": {
+        "interior": {
+          "X2": [
+            {
+              "Plurality": {
+                "id": "Technical",
+                "part": "Voice",
+              },
+            },
+            {
+              "GeneralIndex": 3,
+            },
+          ],
+        },
+        "parents": 0,
+      },
+    },
+    "method": "Sent",
+    "section": "polkadotXcm",
+  },
+]
+`;
+
+exports[`asset hub & bulletin & collectives > Asset Hub authorizes Bulletin upgrade via Collectives > events after notePreimge 1`] = `
+[
+  {
+    "data": {
+      "hash_": "(hash)",
+    },
+    "method": "Noted",
+    "section": "preimage",
+  },
+]
+`;
+
+exports[`asset hub & bulletin & collectives > Asset Hub authorizes Bulletin upgrade via Collectives > events when dispatching non-whitelisted call 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x03000000",
+            "index": 64,
+          },
+        },
+      },
+      "task": "(redacted)",
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`asset hub & bulletin & collectives > Asset Hub authorizes Bulletin upgrade via Collectives > events when dispatching whitelisted call with bad origin 1`] = `
+[
+  {
+    "data": {
+      "id": null,
+      "result": {
+        "Err": "BadOrigin",
+      },
+      "task": "(redacted)",
+    },
+    "method": "Dispatched",
+    "section": "scheduler",
+  },
+]
+`;
+
+exports[`asset hub & bulletin & collectives > Asset Hub authorizes Bulletin upgrade via Collectives > governing chain events about dispatching whitelisted call 1`] = `
+[
+  {
+    "data": {
+      "callHash": "0xd9ea40c3d0e00fa36850427794d57d192be777751c390fc9693d780d00c59f60",
+      "result": {
+        "Ok": {
+          "actualWeight": {
+            "proofSize": "(rounded 4000)",
+            "refTime": "(rounded 200000000)",
+          },
+          "paysFee": "Yes",
+        },
+      },
+    },
+    "method": "WhitelistedCallDispatched",
+    "section": "whitelist",
+  },
+]
+`;
+
+exports[`asset hub & bulletin & collectives > Asset Hub authorizes Bulletin upgrade via Collectives > governing chain events emitted on receiving xcm from collectives 1`] = `
+[
+  {
+    "data": {
+      "callHash": "0xd9ea40c3d0e00fa36850427794d57d192be777751c390fc9693d780d00c59f60",
+    },
+    "method": "CallWhitelisted",
+    "section": "whitelist",
+  },
+  {
+    "data": {
+      "id": "(redacted)",
+      "origin": {
+        "Sibling": "(rounded 1000)",
+      },
+      "success": true,
+      "weightUsed": {
+        "proofSize": "(rounded 4000)",
+        "refTime": "(rounded 100000000)",
+      },
+    },
+    "method": "Processed",
+    "section": "messageQueue",
+  },
+]
+`;
+
+exports[`asset hub & bulletin & collectives > Asset Hub authorizes Bulletin upgrade via Collectives > to-be-upgraded chain events to confirm authorized upgrade 1`] = `
+[
+  {
+    "data": {
+      "checkVersion": true,
+      "codeHash": "0x0101010101010101010101010101010101010101010101010101010101010101",
+    },
+    "method": "UpgradeAuthorized",
+    "section": "system",
+  },
+  {
+    "data": {
+      "id": "(redacted)",
+      "origin": {
+        "Sibling": 1000,
+      },
+      "success": true,
+      "weightUsed": {
+        "proofSize": 0,
+        "refTime": "(rounded 100000000)",
+      },
+    },
+    "method": "Processed",
+    "section": "messageQueue",
+  },
+]
+`;

--- a/packages/polkadot/src/__snapshots__/assetHubPolkadot.bulletinPolkadot.xcm.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/assetHubPolkadot.bulletinPolkadot.xcm.test.ts.snap
@@ -1,0 +1,367 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`assetHubPolkadot & bulletinPolkadot > assetHubPolkadot transfer DOT to bulletinPolkadot > balance on from chain 1`] = `
+{
+  "consumers": 0,
+  "data": {
+    "flags": 0,
+    "free": 10000000000000,
+    "frozen": 0,
+    "reserved": 0,
+  },
+  "nonce": 0,
+  "providers": 1,
+  "sufficients": 0,
+}
+`;
+
+exports[`assetHubPolkadot & bulletinPolkadot > assetHubPolkadot transfer DOT to bulletinPolkadot > balance on to chain 1`] = `
+{
+  "consumers": 0,
+  "data": {
+    "flags": "0x80000000000000000000000000000000",
+    "free": "(rounded 1000000000000)",
+    "frozen": 0,
+    "reserved": 0,
+  },
+  "nonce": 0,
+  "providers": 1,
+  "sufficients": 0,
+}
+`;
+
+exports[`assetHubPolkadot & bulletinPolkadot > assetHubPolkadot transfer DOT to bulletinPolkadot > from chain hrmp messages 1`] = `[]`;
+
+exports[`assetHubPolkadot & bulletinPolkadot > assetHubPolkadot transfer DOT to bulletinPolkadot > to chain xcm events 1`] = `
+[
+  {
+    "data": {
+      "id": "(hash)",
+      "origin": {
+        "Sibling": 1000,
+      },
+      "success": true,
+      "weightUsed": {
+        "proofSize": "(rounded 7000)",
+        "refTime": "(rounded 200000000)",
+      },
+    },
+    "method": "Processed",
+    "section": "messageQueue",
+  },
+]
+`;
+
+exports[`assetHubPolkadot & bulletinPolkadot > assetHubPolkadot transfer DOT to bulletinPolkadot > tx events 1`] = `
+[
+  {
+    "data": {
+      "outcome": {
+        "Complete": {
+          "used": {
+            "proofSize": "(rounded 4000)",
+            "refTime": "(rounded 200000000)",
+          },
+        },
+      },
+    },
+    "method": "Attempted",
+    "section": "polkadotXcm",
+  },
+  {
+    "data": {
+      "fees": [
+        {
+          "fun": {
+            "Fungible": "(rounded 300000000)",
+          },
+          "id": {
+            "interior": "Here",
+            "parents": 1,
+          },
+        },
+      ],
+      "paying": {
+        "interior": {
+          "X1": [
+            {
+              "AccountId32": {
+                "id": "(hash)",
+                "network": "Polkadot",
+              },
+            },
+          ],
+        },
+        "parents": 0,
+      },
+    },
+    "method": "FeesPaid",
+    "section": "polkadotXcm",
+  },
+  {
+    "data": {
+      "destination": {
+        "interior": {
+          "X1": [
+            {
+              "Parachain": "(rounded 1000)",
+            },
+          ],
+        },
+        "parents": 1,
+      },
+      "message": [
+        {
+          "ReceiveTeleportedAsset": [
+            {
+              "fun": {
+                "Fungible": 1000000000000,
+              },
+              "id": {
+                "interior": "Here",
+                "parents": 1,
+              },
+            },
+          ],
+        },
+        "ClearOrigin",
+        {
+          "BuyExecution": {
+            "fees": {
+              "fun": {
+                "Fungible": 1000000000000,
+              },
+              "id": {
+                "interior": "Here",
+                "parents": 1,
+              },
+            },
+            "weightLimit": "Unlimited",
+          },
+        },
+        {
+          "DepositAsset": {
+            "assets": {
+              "Wild": {
+                "AllCounted": 1,
+              },
+            },
+            "beneficiary": {
+              "interior": {
+                "X1": [
+                  {
+                    "AccountId32": {
+                      "id": "(hash)",
+                      "network": null,
+                    },
+                  },
+                ],
+              },
+              "parents": 0,
+            },
+          },
+        },
+      ],
+      "messageId": "(hash)",
+      "origin": {
+        "interior": {
+          "X1": [
+            {
+              "AccountId32": {
+                "id": "(hash)",
+                "network": "Polkadot",
+              },
+            },
+          ],
+        },
+        "parents": 0,
+      },
+    },
+    "method": "Sent",
+    "section": "polkadotXcm",
+  },
+]
+`;
+
+exports[`assetHubPolkadot & bulletinPolkadot > bulletinPolkadot transfer DOT to assetHubPolkadot > balance on from chain 1`] = `
+{
+  "consumers": 0,
+  "data": {
+    "flags": 0,
+    "free": 10000000000000,
+    "frozen": 0,
+    "reserved": 0,
+  },
+  "nonce": 0,
+  "providers": 1,
+  "sufficients": 0,
+}
+`;
+
+exports[`assetHubPolkadot & bulletinPolkadot > bulletinPolkadot transfer DOT to assetHubPolkadot > balance on to chain 1`] = `
+{
+  "consumers": 0,
+  "data": {
+    "flags": "0x80000000000000000000000000000000",
+    "free": "(rounded 1000000000000)",
+    "frozen": 0,
+    "reserved": 0,
+  },
+  "nonce": 0,
+  "providers": 1,
+  "sufficients": 0,
+}
+`;
+
+exports[`assetHubPolkadot & bulletinPolkadot > bulletinPolkadot transfer DOT to assetHubPolkadot > from chain hrmp messages 1`] = `[]`;
+
+exports[`assetHubPolkadot & bulletinPolkadot > bulletinPolkadot transfer DOT to assetHubPolkadot > to chain xcm events 1`] = `
+[
+  {
+    "data": {
+      "id": "(hash)",
+      "origin": {
+        "Sibling": "(rounded 1000)",
+      },
+      "success": true,
+      "weightUsed": {
+        "proofSize": "(rounded 10000)",
+        "refTime": "(rounded 400000000)",
+      },
+    },
+    "method": "Processed",
+    "section": "messageQueue",
+  },
+]
+`;
+
+exports[`assetHubPolkadot & bulletinPolkadot > bulletinPolkadot transfer DOT to assetHubPolkadot > tx events 1`] = `
+[
+  {
+    "data": {
+      "outcome": {
+        "Complete": {
+          "used": {
+            "proofSize": "(rounded 4000)",
+            "refTime": "(rounded 200000000)",
+          },
+        },
+      },
+    },
+    "method": "Attempted",
+    "section": "polkadotXcm",
+  },
+  {
+    "data": {
+      "fees": [
+        {
+          "fun": {
+            "Fungible": "(rounded 300000000)",
+          },
+          "id": {
+            "interior": "Here",
+            "parents": 1,
+          },
+        },
+      ],
+      "paying": {
+        "interior": {
+          "X1": [
+            {
+              "AccountId32": {
+                "id": "(hash)",
+                "network": "Polkadot",
+              },
+            },
+          ],
+        },
+        "parents": 0,
+      },
+    },
+    "method": "FeesPaid",
+    "section": "polkadotXcm",
+  },
+  {
+    "data": {
+      "destination": {
+        "interior": {
+          "X1": [
+            {
+              "Parachain": 1000,
+            },
+          ],
+        },
+        "parents": 1,
+      },
+      "message": [
+        {
+          "ReceiveTeleportedAsset": [
+            {
+              "fun": {
+                "Fungible": 1000000000000,
+              },
+              "id": {
+                "interior": "Here",
+                "parents": 1,
+              },
+            },
+          ],
+        },
+        "ClearOrigin",
+        {
+          "BuyExecution": {
+            "fees": {
+              "fun": {
+                "Fungible": 1000000000000,
+              },
+              "id": {
+                "interior": "Here",
+                "parents": 1,
+              },
+            },
+            "weightLimit": "Unlimited",
+          },
+        },
+        {
+          "DepositAsset": {
+            "assets": {
+              "Wild": {
+                "AllCounted": 1,
+              },
+            },
+            "beneficiary": {
+              "interior": {
+                "X1": [
+                  {
+                    "AccountId32": {
+                      "id": "(hash)",
+                      "network": null,
+                    },
+                  },
+                ],
+              },
+              "parents": 0,
+            },
+          },
+        },
+      ],
+      "messageId": "(hash)",
+      "origin": {
+        "interior": {
+          "X1": [
+            {
+              "AccountId32": {
+                "id": "(hash)",
+                "network": "Polkadot",
+              },
+            },
+          ],
+        },
+        "parents": 0,
+      },
+    },
+    "method": "Sent",
+    "section": "polkadotXcm",
+  },
+]
+`;

--- a/packages/polkadot/src/assetHubPolkadot.bulletinPolkadot.collectivesPolkadot.upgrade.e2e.test.ts
+++ b/packages/polkadot/src/assetHubPolkadot.bulletinPolkadot.collectivesPolkadot.upgrade.e2e.test.ts
@@ -1,0 +1,33 @@
+import { assetHubPolkadot, bulletinPolkadot, collectivesPolkadot } from '@e2e-test/networks/chains'
+import { registerTestTree, setupNetworks, type TestConfig } from '@e2e-test/shared'
+import {
+  authorizeUpgradeViaCollectives,
+  governanceChainUpgradesOtherChainViaWhitelistedCallerReferendumSuite,
+} from '@e2e-test/shared/upgrade.js'
+
+import { describe, test } from 'vitest'
+
+describe('asset hub & bulletin & collectives', async () => {
+  const [assetHubPolkadotClient, bulletinClient, collectivesClient] = await setupNetworks(
+    assetHubPolkadot,
+    bulletinPolkadot,
+    collectivesPolkadot,
+  )
+
+  test('Asset Hub authorizes Bulletin upgrade via Collectives', async () => {
+    await authorizeUpgradeViaCollectives(assetHubPolkadotClient, bulletinClient, collectivesClient)
+  })
+})
+
+const testConfig: TestConfig = {
+  testSuiteName: 'asset hub & bulletin & collectives',
+}
+
+registerTestTree(
+  governanceChainUpgradesOtherChainViaWhitelistedCallerReferendumSuite(
+    assetHubPolkadot,
+    bulletinPolkadot,
+    collectivesPolkadot,
+    testConfig,
+  ),
+)

--- a/packages/polkadot/src/assetHubPolkadot.bulletinPolkadot.upgrade.e2e.test.ts
+++ b/packages/polkadot/src/assetHubPolkadot.bulletinPolkadot.upgrade.e2e.test.ts
@@ -1,0 +1,14 @@
+import { assetHubPolkadot, bulletinPolkadot } from '@e2e-test/networks/chains'
+import {
+  governanceChainUpgradesOtherChainViaRootReferendumSuite,
+  registerTestTree,
+  type TestConfig,
+} from '@e2e-test/shared'
+
+const testConfig: TestConfig = {
+  testSuiteName: 'assetHubPolkadot & bulletinPolkadot',
+}
+
+registerTestTree(
+  governanceChainUpgradesOtherChainViaRootReferendumSuite(assetHubPolkadot, bulletinPolkadot, testConfig),
+)

--- a/packages/polkadot/src/assetHubPolkadot.bulletinPolkadot.xcm.test.ts
+++ b/packages/polkadot/src/assetHubPolkadot.bulletinPolkadot.xcm.test.ts
@@ -1,0 +1,40 @@
+import { defaultAccounts } from '@e2e-test/networks'
+import { assetHubPolkadot, bulletinPolkadot } from '@e2e-test/networks/chains'
+import { setupNetworks } from '@e2e-test/shared'
+import { query, tx } from '@e2e-test/shared/api'
+import { runXcmPalletHorizontal } from '@e2e-test/shared/xcm'
+
+import { describe } from 'vitest'
+
+describe('assetHubPolkadot & bulletinPolkadot', async () => {
+  const [assetHubPolkadotClient, bulletinPolkadotClient] = await setupNetworks(assetHubPolkadot, bulletinPolkadot)
+
+  const bulletinDOT = bulletinPolkadot.custom.dot
+  const polkadotDOT = assetHubPolkadot.custom.dot
+
+  runXcmPalletHorizontal('assetHubPolkadot transfer DOT to bulletinPolkadot', async () => {
+    return {
+      fromChain: assetHubPolkadotClient,
+      toChain: bulletinPolkadotClient,
+      fromBalance: query.balances,
+      toBalance: query.balances,
+      toAccount: defaultAccounts.dave,
+      tx: tx.xcmPallet.limitedTeleportAssets(polkadotDOT, 1e12, tx.xcmPallet.parachainV3(1, bulletinPolkadot.paraId!)),
+    }
+  })
+
+  runXcmPalletHorizontal('bulletinPolkadot transfer DOT to assetHubPolkadot', async () => {
+    return {
+      fromChain: bulletinPolkadotClient,
+      toChain: assetHubPolkadotClient,
+      fromBalance: query.balances,
+      toBalance: query.balances,
+      toAccount: defaultAccounts.dave,
+      tx: tx.xcmPallet.limitedTeleportAssets(
+        bulletinDOT,
+        1e12,
+        tx.xcmPallet.parachainV3(1, assetHubPolkadotClient.config.paraId!),
+      ),
+    }
+  })
+})

--- a/packages/polkadot/src/bulletinPolkadot.system.e2e.test.ts
+++ b/packages/polkadot/src/bulletinPolkadot.system.e2e.test.ts
@@ -1,0 +1,8 @@
+import { assetHubPolkadot, bulletinPolkadot } from '@e2e-test/networks/chains'
+import { registerTestTree, systemE2ETestsViaRemoteScheduler, type TestConfig } from '@e2e-test/shared'
+
+const testConfigForAssetHub: TestConfig = {
+  testSuiteName: 'Polkadot Bulletin System',
+}
+
+registerTestTree(systemE2ETestsViaRemoteScheduler(assetHubPolkadot, bulletinPolkadot, testConfigForAssetHub))

--- a/scripts/generate-ci-matrix.mjs
+++ b/scripts/generate-ci-matrix.mjs
@@ -35,6 +35,7 @@ const CHAIN_ORDER = {
 		'collectivesPolkadot',
 		'coretimePolkadot',
 		'peoplePolkadot',
+		'bulletinPolkadot',
 		'acala',
 		'astar',
 		'hydration',

--- a/scripts/generate-ci-matrix.mjs
+++ b/scripts/generate-ci-matrix.mjs
@@ -56,7 +56,7 @@ const CHAIN_ORDER = {
 /** Base port for each network group. Chains get consecutive ports from here. */
 const PORT_BASES = {
 	polkadot: 9000,
-	kusama: 9010,
+	kusama: 9100,
 }
 
 /** Convert chain name to the env var name used by workflows (e.g. "assetHubPolkadot" -> "ASSETHUBPOLKADOT_ENDPOINT") */
@@ -113,5 +113,19 @@ const matrix = ['polkadot', 'kusama'].map((networkName) => ({
 		}
 	}),
 }))
+
+// Ports come from a per-network base plus the chain's index, so a network that outgrows the gap to
+// the next base starts handing out ports the other network already claims.
+const portOwners = new Map()
+for (const network of matrix) {
+	for (const { chain, port } of network.chains) {
+		const owner = `${network.name}:${chain}`
+		const existing = portOwners.get(port)
+		if (existing !== undefined) {
+			throw new Error(`Port ${port} claimed by both ${existing} and ${owner}: raise a base in PORT_BASES`)
+		}
+		portOwners.set(port, owner)
+	}
+}
 
 process.stdout.write(JSON.stringify(matrix))

--- a/scripts/run-ci-locally.sh
+++ b/scripts/run-ci-locally.sh
@@ -27,15 +27,16 @@ if [[ -z "$NETWORK" ]]; then
 fi
 shift
 
-# Chain/port/env-var triples per network, hardcoded to mirror the matrix in
-# .github/workflows/ci.yml. Kept literal here (rather than parsed from the
-# YAML) for two reasons: (1) no YAML parser dependency for a local script,
-# (2) drift between this script and the CI workflow is rare and obvious in
-# review when both change. If a chain is added to CI, mirror it here.
+# Chain/port/env-var triples per network, hardcoded to mirror the output of
+# scripts/generate-ci-matrix.mjs (which .github/workflows/ci.yml consumes).
+# Kept literal here (rather than generated) for two reasons: (1) no node
+# dependency before the tool checks below, (2) drift between this script and
+# the CI matrix is rare and obvious in review when both change. If a chain is
+# added to CHAIN_ORDER or a base changes in PORT_BASES, mirror it here.
 #
 # `both` runs polkadot + kusama in a single tmux session. Westend is
 # intentionally excluded because CI does not run a Westend job (the matrix
-# in .github/workflows/ci.yml only covers polkadot and kusama).
+# only covers polkadot and kusama).
 POLKADOT_CHAINS=(
   "polkadot:9000:POLKADOT_ENDPOINT"
   "assetHubPolkadot:9001:ASSETHUBPOLKADOT_ENDPOINT"
@@ -43,19 +44,21 @@ POLKADOT_CHAINS=(
   "collectivesPolkadot:9003:COLLECTIVESPOLKADOT_ENDPOINT"
   "coretimePolkadot:9004:CORETIMEPOLKADOT_ENDPOINT"
   "peoplePolkadot:9005:PEOPLEPOLKADOT_ENDPOINT"
-  "acala:9006:ACALA_ENDPOINT"
-  "hydration:9007:HYDRATION_ENDPOINT"
-  "bifrostPolkadot:9008:BIFROSTPOLKADOT_ENDPOINT"
+  "bulletinPolkadot:9006:BULLETINPOLKADOT_ENDPOINT"
+  "acala:9007:ACALA_ENDPOINT"
+  "astar:9008:ASTAR_ENDPOINT"
+  "hydration:9009:HYDRATION_ENDPOINT"
+  "bifrostPolkadot:9010:BIFROSTPOLKADOT_ENDPOINT"
 )
 KUSAMA_CHAINS=(
-  "kusama:9010:KUSAMA_ENDPOINT"
-  "assetHubKusama:9011:ASSETHUBKUSAMA_ENDPOINT"
-  "bridgeHubKusama:9012:BRIDGEHUBKUSAMA_ENDPOINT"
-  "coretimeKusama:9013:CORETIMEKUSAMA_ENDPOINT"
-  "peopleKusama:9014:PEOPLEKUSAMA_ENDPOINT"
-  "encointerKusama:9015:ENCOINTERKUSAMA_ENDPOINT"
-  "karura:9016:KARURA_ENDPOINT"
-  "bifrostKusama:9017:BIFROSTKUSAMA_ENDPOINT"
+  "kusama:9100:KUSAMA_ENDPOINT"
+  "assetHubKusama:9101:ASSETHUBKUSAMA_ENDPOINT"
+  "bridgeHubKusama:9102:BRIDGEHUBKUSAMA_ENDPOINT"
+  "coretimeKusama:9103:CORETIMEKUSAMA_ENDPOINT"
+  "peopleKusama:9104:PEOPLEKUSAMA_ENDPOINT"
+  "encointerKusama:9105:ENCOINTERKUSAMA_ENDPOINT"
+  "karura:9106:KARURA_ENDPOINT"
+  "bifrostKusama:9107:BIFROSTKUSAMA_ENDPOINT"
 )
 
 case "$NETWORK" in


### PR DESCRIPTION
Bulletin Polkadot had a chain definition and an accounts test. This adds it to the remaining suites the other Polkadot system parachains run.

## Tests

- `bulletinPolkadot.system.e2e.test.ts` — `systemE2ETestsViaRemoteScheduler(assetHubPolkadot, bulletinPolkadot)`
- `assetHubPolkadot.bulletinPolkadot.upgrade.e2e.test.ts` — `governanceChainUpgradesOtherChainViaRootReferendumSuite`
- `assetHubPolkadot.bulletinPolkadot.collectivesPolkadot.upgrade.e2e.test.ts` — `governanceChainUpgradesOtherChainViaWhitelistedCallerReferendumSuite` plus `authorizeUpgradeViaCollectives`
- `assetHubPolkadot.bulletinPolkadot.xcm.test.ts` — `runXcmPalletHorizontal`, DOT teleport in both directions

Bulletin has no local scheduler and is governed from the Asset Hub, so the system suite uses the remote-scheduler variant, as Coretime and People do.

`multisig`, `proxy`, `multisig.proxy`, `preimage` and `scheduler` are omitted because Bulletin has none of those pallets.

## CI matrix

`CHAIN_ORDER.polkadot` did not list `bulletinPolkadot`, so CI started no Subway instance for it and the accounts test resolved to the public endpoint. Adding it after `peoplePolkadot` gives it port 9006.

That made the Polkadot list 11 chains, spanning 9000 to 9010, which collided with the Kusama base at 9010: `bifrostPolkadot` and `kusama` were both assigned 9010. `PORT_BASES.kusama` moves to 9100, and the generator now throws when two chains claim the same port.

`run-ci-locally.sh` keeps a hardcoded copy of the chain/port map and is updated to match: `bulletinPolkadot` on 9006, the shifted Polkadot ports, and the new Kusama base. This also repairs drift that predates this PR — `astar` was missing from the mirror and the `hydration`/`bifrostPolkadot` ports were stale.
