### PR TITLE
Fix two test failures against runtime 2.4

### DIFF
--- a/packages/shared/src/configuration.ts
+++ b/packages/shared/src/configuration.ts
@@ -394,7 +394,7 @@ export async function configurationTest<
 
 /**
  * Schedules `calls` twice with Root origin and asserts the resulting pending config is
- * identical both times — i.e., re-scheduling the same calls is idempotent.
+ * identical both times. Re-scheduling the same calls is idempotent.
  */
 async function assertIdempotent(
   client: Client<any, any>,
@@ -414,7 +414,7 @@ async function assertIdempotent(
 
 /**
  * Verifies that scheduling the same configuration change twice leaves the pending config
- * unchanged — i.e., the second scheduling is idempotent and does not alter any field
+ * unchanged. The second scheduling is idempotent and does not alter any field
  * that was not explicitly set. Covers all call groups.
  */
 export async function configurationIdempotencyTest<
@@ -518,7 +518,7 @@ export async function configurationIdempotencyTest<
 }
 
 /**
- * Verifies that scheduling a value Y and then Z for the same field results in Z —
+ * Verifies that scheduling a value Y and then Z for the same field results in Z:
  * i.e., later scheduled values overwrite earlier ones and the intermediate value Y
  * is not preserved. Covers all call groups.
  */
@@ -932,10 +932,10 @@ export async function configurationSameBlockMergeTest<
 /**
  * Exercises the full 2×2 consistency-check matrix:
  *
- *   Case 1 — Consistent base + inconsistent new → rejected (InvalidNewValue)
- *   Case 2 — Inconsistent base + inconsistent new → accepted (recovery path)
- *   Case 3 — Inconsistent base + consistent new → accepted
- *   Case 4 — Bypass flag on → inconsistent value accepted unconditionally
+ *   Case 1. Consistent base + inconsistent new → rejected (InvalidNewValue)
+ *   Case 2. Inconsistent base + inconsistent new → accepted (recovery path)
+ *   Case 3. Inconsistent base + consistent new → accepted
+ *   Case 4. Bypass flag on → inconsistent value accepted unconditionally
  *
  * All possible consistency violations are tested in Cases 1, 2, and 4.
  */

--- a/packages/shared/src/configuration.ts
+++ b/packages/shared/src/configuration.ts
@@ -958,7 +958,7 @@ export async function configurationConsistencyMatrixTest<
       configuration: {
         activeConfig: {
           ...activeConfigJson,
-          maxCodeSize: 3_145_729, // one above MAX_CODE_SIZE — inconsistent but safe for block production
+          maxCodeSize: 5_242_881, // one above MAX_CODE_SIZE: inconsistent but safe for block production
         },
       },
     })
@@ -966,7 +966,7 @@ export async function configurationConsistencyMatrixTest<
   const restoreActiveConfig = () => client.dev.setStorage({ configuration: { activeConfig: activeConfigJson } })
 
   // Hard-limit boundary values (each is max_allowed + 1)
-  const improperMaxCodeSize = 3_145_729 // > MAX_CODE_SIZE (3,145,728)
+  const improperMaxCodeSize = 5_242_881 // > MAX_CODE_SIZE (5,242,880)
   const improperMaxHeadDataSize = 1_048_577 // > MAX_HEAD_DATA_SIZE (1,048,576)
   const improperMaxPovSize = 16_777_217 // > POV_SIZE_HARD_LIMIT (16,777,216)
   const improperMaxUpwardMessageSize = 131_073 // > MAX_UPWARD_MESSAGE_SIZE_BOUND (131,072)

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -168,7 +168,7 @@ export async function missingDecisionDepositTest<
   })
 
   /**
-   * 2. Check the referendum's data — decision deposit should be absent
+   * 2. Check the referendum's data. The decision deposit should be absent
    */
 
   let referendumDataOpt = (await client.api.query.referenda.referendumInfoFor(
@@ -1261,7 +1261,7 @@ async function verifyRejection(
   expect(rejectedRef[2].isSome, 'decision deposit should be present after rejection').toBe(true)
 
   /**
-   * 3. Refund the decision deposit — this should succeed for rejected referenda
+   * 3. Refund the decision deposit. This should succeed for rejected referenda
    */
 
   const refundDecisionTx = client.api.tx.referenda.refundDecisionDeposit(referendumIndex)
@@ -1273,7 +1273,7 @@ async function verifyRejection(
     .toMatchSnapshot(`decision deposit refund after rejection (${scenarioLabel}) - ${trackLabel}`)
 
   /**
-   * 4. Attempt to refund the submission deposit — this should fail with `BadStatus`
+   * 4. Attempt to refund the submission deposit. This should fail with `BadStatus`
    */
 
   const refundSubmissionTx = client.api.tx.referenda.refundSubmissionDeposit(referendumIndex)
@@ -1753,7 +1753,7 @@ export async function overflowPromotionViaRejectionTest<
    *
    * Backdating `deciding.since` so the decision period has elapsed by the next block.
    * A nay-only tally is injected because `Perbill::from_rational(0, 0)` returns 100 %
-   * in Substrate — an empty tally would pass approval and enter confirmation instead.
+   * in Substrate. An empty tally would pass approval and enter confirmation instead.
    */
 
   const block = (await client.api.rpc.chain.getHeader()).number.toNumber()

--- a/packages/shared/src/governance.ts
+++ b/packages/shared/src/governance.ts
@@ -1812,18 +1812,64 @@ export async function overflowPromotionViaRejectionTest<
 /**
  * Test that the overflow referendum is promoted after the blocker is killed:
  * 1–4. shared setup (submit both refs, queue the overflow)
- * 5. killing the blocker with a Root-origin call via the scheduler
- * 6. verifying the blocker is killed and the overflow is promoted to deciding
+ * 5. putting the blocker into its decision period, so its kill frees track capacity
+ * 6. killing the blocker with a Root-origin call via the scheduler
+ * 7. verifying the blocker is killed and the overflow is promoted to deciding
  */
 export async function overflowPromotionViaKillTest<
   TCustom extends Record<string, unknown> | undefined,
   TInitStorages extends Record<string, Record<string, any>> | undefined,
 >(client: Client<TCustom, TInitStorages>, trackConfig: GovernanceTrackConfig) {
   const ctx = await setupOverflow(client, trackConfig)
-  const { blockerIndex, overflowIndex, maxDeciding } = ctx
+  const { blockerIndex, blockerOngoing, overflowIndex, maxDeciding, prepPeriod } = ctx
 
   /**
-   * 5. Kill the blocker with a Root-origin call via the scheduler
+   * 5. Put the blocker into its decision period
+   *
+   * `kill` only calls `note_one_fewer_deciding` when the referendum it removes was deciding:
+   *
+   * ```
+   * if status.deciding.is_some() {
+   *     Self::note_one_fewer_deciding(status.track);
+   * }
+   * ```
+   *
+   * `setupOverflow` fills the track by writing `DecidingCount`, which leaves the blocker itself
+   * with `deciding: None`. Killing it in that state frees no capacity, so the queued overflow
+   * stays queued and step 7 fails. Injecting `deciding` makes the kill release the slot the
+   * blocker occupies in `DecidingCount`.
+   */
+
+  const blockerBlock = (await client.api.rpc.chain.getHeader()).number.toNumber()
+  const blockerDecidingSince = blockerBlock + 1
+
+  await client.dev.setStorage({
+    Referenda: {
+      ReferendumInfoFor: [
+        [
+          [blockerIndex],
+          {
+            Ongoing: {
+              track: blockerOngoing.track,
+              origin: blockerOngoing.origin,
+              proposal: blockerOngoing.proposal,
+              enactment: blockerOngoing.enactment,
+              submitted: blockerDecidingSince - prepPeriod,
+              submissionDeposit: blockerOngoing.submissionDeposit,
+              decisionDeposit: blockerOngoing.decisionDeposit,
+              deciding: { since: blockerDecidingSince, confirming: null },
+              tally: blockerOngoing.tally,
+              inQueue: false,
+              alarm: blockerOngoing.alarm,
+            },
+          },
+        ],
+      ],
+    },
+  })
+
+  /**
+   * 6. Kill the blocker with a Root-origin call via the scheduler
    */
 
   const schedulerBlock =
@@ -1851,7 +1897,7 @@ export async function overflowPromotionViaKillTest<
   expect(blockerResultOpt.unwrap().isKilled, 'blocker should have been killed').toBe(true)
 
   /**
-   * 6. Verify the overflow was promoted
+   * 7. Verify the overflow was promoted
    */
 
   await client.dev.newBlock()


### PR DESCRIPTION
Two tests fail against runtime 2.4. Both failures are test defects, not runtime defects.

Failing CI run: [polkadot-fellows/runtimes#1255](https://github.com/polkadot-fellows/runtimes/pull/1255). Failing jobs: [PET (kusama, shard 2/3)](https://github.com/polkadot-fellows/runtimes/actions/runs/32927696983/job/98085851705), [PET (kusama, shard 3/3)](https://github.com/polkadot-fellows/runtimes/actions/runs/32927696983/job/98085851761), [PET (polkadot, shard 3/3)](https://github.com/polkadot-fellows/runtimes/actions/runs/32927696983/job/98085851774).

That PR changes weights and spec versions only. It changes no configuration parameter and no governance logic.

## 1. `configuration test - consistency check 2 by 2 matrix`

```
AssertionError: expected 16 to be 17
  ❯ configurationConsistencyMatrixTest packages/shared/src/configuration.ts:1061
```

The test sends 17 values that each break a consistency rule. It then counts the `InvalidNewValue` errors. Only 16 calls failed.

An instrumented run names the accepted call:

```
#6 setMaxCodeSize -> Ok(ACCEPTED!)
   (the other 16 -> Err(configuration.InvalidNewValue))
```

`MAX_CODE_SIZE` rose from `3 * 1024 * 1024` to `5 * 1024 * 1024` upstream. The test used `3_145_729`, which was `MAX_CODE_SIZE + 1` under the old limit. Under 2.4 that value is legal, so the runtime accepts it.

This PR raises both copies of the constant to `5_242_881`. The `breakActiveConfig` helper holds the second copy.

Do not derive this value from `activeConfig.maxCodeSize`. Polkadot configures `3_145_728` while the hard limit is `5_242_880`. The two values are unrelated.

The remaining 16 boundary values were each checked against polkadot-sdk `master`. All remain correct.

## 2. `track capacity overflow > promotion via kill`

```
AssertionError: overflow should now be in decision phase: expected false to be true
  ❯ verifyPromotion             packages/shared/src/governance.ts:1634
  ❯ overflowPromotionViaKillTest packages/shared/src/governance.ts:1858
```

`kill` frees track capacity only when the referendum is deciding:

```rust
if status.deciding.is_some() {
    Self::note_one_fewer_deciding(status.track);
}
```

`setupOverflow` fills the track by writing `DecidingCount` directly. The blocker keeps `deciding: None`. The kill therefore frees no capacity.

Probe output before the fix:

```
pre-kill blocker isOngoing=true deciding=false
pre-kill decidingCount=3   (maxDeciding=3)
after kill: no one_fewer_deciding in the scheduler agenda
+1..+5 blocks: decidingCount stays 3, overflow inQueue=true
```

This PR puts the blocker into its decision period before the kill. The runtime then releases the slot and promotes the queued overflow.

`promotion via approval` and `promotion via rejection` pass because the runtime itself advances those referenda into `Deciding`.

This defect predates runtime 2.4. The test passes against the live runtime by coincidence.

## Verification

Each run used the runtime 2.4 WASM artifacts from the failing CI run.

| Test | Runtime 2.4 | Live |
|---|---|---|
| `polkadot.configuration` consistency matrix | pass | pass |
| `kusama.configuration` consistency matrix | pass | pass |
| `assetHubPolkadot` overflow (9 tests) | pass | pass |
| `assetHubKusama` overflow (9 tests) | pass | pass |

The full governance suites also run on both live chains: 41 of 42 tests pass.

The one failure is `assetHubKusama > removal of votes in cancelled referendum`. It is a
weight drift in a snapshot this PR does not touch:

```
- "refTime": "(rounded 900000000)"
+ "refTime": "(rounded 800000000)"
```

The same failure reproduces on pristine `master`. It needs a separate `yarn test -u`.

`yarn lint` passes.

