### PR TITLE
Cover add_proxy in the proxy call filtering tests

### DIFF
--- a/packages/kusama/src/__snapshots__/assetHubKusama.proxy.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/assetHubKusama.proxy.e2e.test.ts.snap
@@ -1831,6 +1831,18 @@ exports[`Kusama AssetHub Proxy full tests (includes call filtering) > filtering 
 ]
 `;
 
+exports[`Kusama AssetHub Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
+[
+  {
+    "data": {
+      "result": "Ok",
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
 exports[`Kusama AssetHub Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call reject_announcement 1`] = `
 [
   {
@@ -3064,6 +3076,25 @@ exports[`Kusama AssetHub Proxy full tests (includes call filtering) > filtering 
 `;
 
 exports[`Kusama AssetHub Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet balances, call burn 1`] = `
+[
+  {
+    "data": {
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x05000000",
+            "index": 0,
+          },
+        },
+      },
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
+exports[`Kusama AssetHub Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
 [
   {
     "data": {

--- a/packages/kusama/src/__snapshots__/bridgeHubKusama.proxy.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/bridgeHubKusama.proxy.e2e.test.ts.snap
@@ -641,6 +641,18 @@ exports[`Bridge Hub Kusama Proxy full tests (includes call filtering) > filterin
 ]
 `;
 
+exports[`Bridge Hub Kusama Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
+[
+  {
+    "data": {
+      "result": "Ok",
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
 exports[`Bridge Hub Kusama Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call reject_announcement 1`] = `
 [
   {
@@ -892,6 +904,25 @@ exports[`Bridge Hub Kusama Proxy full tests (includes call filtering) > filterin
 `;
 
 exports[`Bridge Hub Kusama Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet balances, call burn 1`] = `
+[
+  {
+    "data": {
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x05000000",
+            "index": 0,
+          },
+        },
+      },
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
+exports[`Bridge Hub Kusama Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
 [
   {
     "data": {

--- a/packages/kusama/src/__snapshots__/coretimeKusama.proxy.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/coretimeKusama.proxy.e2e.test.ts.snap
@@ -985,6 +985,18 @@ exports[`Kusama Coretime Proxy full tests (includes call filtering) > filtering 
 ]
 `;
 
+exports[`Kusama Coretime Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
+[
+  {
+    "data": {
+      "result": "Ok",
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
 exports[`Kusama Coretime Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call reject_announcement 1`] = `
 [
   {
@@ -1519,6 +1531,25 @@ exports[`Kusama Coretime Proxy full tests (includes call filtering) > filtering 
 `;
 
 exports[`Kusama Coretime Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet balances, call burn 1`] = `
+[
+  {
+    "data": {
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x05000000",
+            "index": 0,
+          },
+        },
+      },
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
+exports[`Kusama Coretime Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
 [
   {
     "data": {

--- a/packages/kusama/src/__snapshots__/peopleKusama.proxy.e2e.test.ts.snap
+++ b/packages/kusama/src/__snapshots__/peopleKusama.proxy.e2e.test.ts.snap
@@ -926,6 +926,18 @@ exports[`People Kusama Proxy full tests (includes call filtering) > filtering te
 ]
 `;
 
+exports[`People Kusama Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
+[
+  {
+    "data": {
+      "result": "Ok",
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
 exports[`People Kusama Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call reject_announcement 1`] = `
 [
   {
@@ -1386,6 +1398,25 @@ exports[`People Kusama Proxy full tests (includes call filtering) > filtering te
 `;
 
 exports[`People Kusama Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet balances, call burn 1`] = `
+[
+  {
+    "data": {
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x05000000",
+            "index": 0,
+          },
+        },
+      },
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
+exports[`People Kusama Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
 [
   {
     "data": {

--- a/packages/polkadot/src/__snapshots__/assetHubPolkadot.proxy.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/assetHubPolkadot.proxy.e2e.test.ts.snap
@@ -1720,6 +1720,18 @@ exports[`Polkadot AssetHub Proxy full tests (includes call filtering) > filterin
 ]
 `;
 
+exports[`Polkadot AssetHub Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
+[
+  {
+    "data": {
+      "result": "Ok",
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
 exports[`Polkadot AssetHub Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call reject_announcement 1`] = `
 [
   {
@@ -2931,6 +2943,25 @@ exports[`Polkadot AssetHub Proxy full tests (includes call filtering) > filterin
 `;
 
 exports[`Polkadot AssetHub Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet balances, call burn 1`] = `
+[
+  {
+    "data": {
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x05000000",
+            "index": 0,
+          },
+        },
+      },
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
+exports[`Polkadot AssetHub Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
 [
   {
     "data": {

--- a/packages/polkadot/src/__snapshots__/bridgeHubPolkadot.proxy.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/bridgeHubPolkadot.proxy.e2e.test.ts.snap
@@ -641,6 +641,18 @@ exports[`Bridge Hub Polkadot Proxy full tests (includes call filtering) > filter
 ]
 `;
 
+exports[`Bridge Hub Polkadot Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
+[
+  {
+    "data": {
+      "result": "Ok",
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
 exports[`Bridge Hub Polkadot Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call reject_announcement 1`] = `
 [
   {
@@ -892,6 +904,25 @@ exports[`Bridge Hub Polkadot Proxy full tests (includes call filtering) > filter
 `;
 
 exports[`Bridge Hub Polkadot Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet balances, call burn 1`] = `
+[
+  {
+    "data": {
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x05000000",
+            "index": 0,
+          },
+        },
+      },
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
+exports[`Bridge Hub Polkadot Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
 [
   {
     "data": {

--- a/packages/polkadot/src/__snapshots__/collectivesPolkadot.proxy.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/collectivesPolkadot.proxy.e2e.test.ts.snap
@@ -1147,6 +1147,18 @@ exports[`Polkadot Collectives Proxy full tests (includes call filtering) > filte
 ]
 `;
 
+exports[`Polkadot Collectives Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
+[
+  {
+    "data": {
+      "result": "Ok",
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
 exports[`Polkadot Collectives Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call reject_announcement 1`] = `
 [
   {
@@ -1968,6 +1980,25 @@ exports[`Polkadot Collectives Proxy full tests (includes call filtering) > filte
 `;
 
 exports[`Polkadot Collectives Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet balances, call burn 1`] = `
+[
+  {
+    "data": {
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x05000000",
+            "index": 0,
+          },
+        },
+      },
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
+exports[`Polkadot Collectives Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
 [
   {
     "data": {

--- a/packages/polkadot/src/__snapshots__/coretimePolkadot.proxy.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/coretimePolkadot.proxy.e2e.test.ts.snap
@@ -985,6 +985,18 @@ exports[`Polkadot Coretime Proxy full tests (includes call filtering) > filterin
 ]
 `;
 
+exports[`Polkadot Coretime Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
+[
+  {
+    "data": {
+      "result": "Ok",
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
 exports[`Polkadot Coretime Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call reject_announcement 1`] = `
 [
   {
@@ -1519,6 +1531,25 @@ exports[`Polkadot Coretime Proxy full tests (includes call filtering) > filterin
 `;
 
 exports[`Polkadot Coretime Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet balances, call burn 1`] = `
+[
+  {
+    "data": {
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x05000000",
+            "index": 0,
+          },
+        },
+      },
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
+exports[`Polkadot Coretime Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
 [
   {
     "data": {

--- a/packages/polkadot/src/__snapshots__/peoplePolkadot.proxy.e2e.test.ts.snap
+++ b/packages/polkadot/src/__snapshots__/peoplePolkadot.proxy.e2e.test.ts.snap
@@ -926,6 +926,18 @@ exports[`People Polkadot Proxy full tests (includes call filtering) > filtering 
 ]
 `;
 
+exports[`People Polkadot Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
+[
+  {
+    "data": {
+      "result": "Ok",
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
 exports[`People Polkadot Proxy full tests (includes call filtering) > filtering tests for allowed proxy calls > allowed proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call reject_announcement 1`] = `
 [
   {
@@ -1386,6 +1398,25 @@ exports[`People Polkadot Proxy full tests (includes call filtering) > filtering 
 `;
 
 exports[`People Polkadot Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet balances, call burn 1`] = `
+[
+  {
+    "data": {
+      "result": {
+        "Err": {
+          "Module": {
+            "error": "0x05000000",
+            "index": 0,
+          },
+        },
+      },
+    },
+    "method": "ProxyExecuted",
+    "section": "proxy",
+  },
+]
+`;
+
+exports[`People Polkadot Proxy full tests (includes call filtering) > filtering tests for forbidden proxy calls > forbidden proxy calls for NonTransfer > events for proxy type NonTransfer, pallet proxy, call add_proxy 1`] = `
 [
   {
     "data": {

--- a/packages/shared/src/proxy.ts
+++ b/packages/shared/src/proxy.ts
@@ -134,6 +134,7 @@ interface ProxyActionBuilder {
   // a proxy of type A can only remove proxies of type B such that B ≤ A; in other words, the action needs
   // to be given an appropriate proxy type to remove.
   buildProxyRemovalAction(proxyType?: number): ProxyAction[]
+  buildProxyAdditionAction(proxyType?: number): ProxyAction[]
 
   buildSlotsAction(): ProxyAction[]
   buildSocietyAction(): ProxyAction[]
@@ -670,6 +671,29 @@ class ProxyActionBuilderImpl<
     return proxyRemoveProxyCalls
   }
 
+  /**
+   * `pallet_proxy` rejects `add_proxy` when the proxy type of the caller is not a superset of
+   * the requested type. A caller must therefore pass a type that suits the proxy type under
+   * test: a dominated type for an allow list, and a type that is not dominated for a
+   * disallow list.
+   */
+  buildProxyAdditionAction(proxyType?: number): ProxyAction[] {
+    if (proxyType === undefined) {
+      throw new Error('proxy addition action builder requires proxyType')
+    }
+
+    const proxyAddProxyCalls: ProxyAction[] = []
+    if (this.client.api.tx.proxy) {
+      proxyAddProxyCalls.push({
+        pallet: 'proxy',
+        extrinsic: 'add_proxy',
+        call: this.client.api.tx.proxy.addProxy(testAccounts.eve.address, proxyType!, 0),
+      })
+    }
+
+    return proxyAddProxyCalls
+  }
+
   buildSlotsAction(): ProxyAction[] {
     const slotsCalls: ProxyAction[] = []
     if (this.client.api.tx.slots) {
@@ -816,6 +840,15 @@ class ProxyActionBuilderImpl<
  * those of relay and system parachains.
  * Chains can use this as a starting point and override specific proxy types as needed.
  */
+/**
+ * `Any` and `NonTransfer` hold the same index on every network in `proxyTypes.ts`. Other proxy
+ * types do not, so a chain must pass its own index for those.
+ */
+const CANONICAL_PROXY_TYPE_INDEX = {
+  Any: 0,
+  NonTransfer: 1,
+}
+
 export const defaultProxyTypeConfig: ProxyTypeConfig = {
   Any: {
     buildAllowedActions: (builder) => [
@@ -842,11 +875,19 @@ export const defaultProxyTypeConfig: ProxyTypeConfig = {
       ...builder.buildMultisigAction(),
       ...builder.buildNominationPoolsAction(),
       ...builder.buildProxyAction(),
+      // `NonTransfer` is a superset of itself, so it may add a proxy of its own type.
+      ...builder.buildProxyAdditionAction(CANONICAL_PROXY_TYPE_INDEX.NonTransfer),
       ...builder.buildStakingAction(),
       ...builder.buildSystemRemarkAction(),
       ...builder.buildUtilityAction(),
     ],
-    buildDisallowedActions: (builder) => [...builder.buildBalancesAction(), ...builder.buildVestingAction()],
+    buildDisallowedActions: (builder) => [
+      ...builder.buildBalancesAction(),
+      ...builder.buildVestingAction(),
+      // `NonTransfer` must not add an `Any` proxy. An `Any` proxy can move funds, which
+      // `NonTransfer` cannot do.
+      ...builder.buildProxyAdditionAction(CANONICAL_PROXY_TYPE_INDEX.Any),
+    ],
   },
 
   CancelProxy: {


### PR DESCRIPTION
The action builder had no `add_proxy` action. A comment gave the reason: the proxy type of the caller may be a subtype of the type in the call, so one fixed action cannot suit every proxy type.

`buildProxyAdditionAction` takes the type to request, in the same way as `buildProxyRemovalAction`. The `NonTransfer` lists now use it. The allow list requests `NonTransfer`. The disallow list requests `Any`.

`pallet_proxy` rejects `add_proxy` when the type of the caller is not a superset of the requested type. The disallow case gives `CallFiltered` on both Asset Hubs. The allow case succeeds.

`Any` and `NonTransfer` hold the same index on all networks, so every chain that uses `defaultProxyTypeConfig` gains this coverage.
